### PR TITLE
VER: Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
-## 0.5.1 - TBD
+## 0.6.0 - 2024-01-16
+
+#### Enhancements
+- Relaxed version requirements for `tokio`, `tokio-util`, and `thiserror`
+
+#### Breaking changes
+- Updated DBN version to 0.15.0
+  - Added support for larger `SystemMsg` and `ErrorMsg` records
+  - Improved `Debug` implementations for records and `RecordRef`
+  - Improved panic messages for `RecordRef::get`
+- Upgraded `typed-builder` to 0.18
 
 #### Bug fixes
-- Fixed documentation for `end` in `DateTimeRange::Closed`
+- Fixed documentation for `end` in `DateRange::Closed` and `DateTimeRange::Closed`
 
 ## 0.5.0 - 2023-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.1 - TBD
+
+#### Bug fixes
+- Fixed documentation for `end` in `DateTimeRange::Closed`
+
 ## 0.5.0 - 2023-11-23
 
 This release adds support for DBN v2.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -24,7 +24,7 @@ live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
 # binary encoding
-dbn = { version = "0.14.2", features = ["async", "serde"] }
+dbn = { version = "0.15.0", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Hex encoding used for Live authentication
@@ -39,20 +39,20 @@ serde_json = { version = "1.0", optional = true }
 # Used for Live authentication
 sha2 = { version = "0.10", optional = true }
 # Error handling
-thiserror = "1.0.50"
+thiserror = "1.0"
 # Dates and datetimes
 time = { version = "0.3", features = ["macros", "parsing", "serde"] }
 # Async run time
-tokio = { version = "1.34", features = ["io-util", "macros"] }
+tokio = { version = "1", features = ["io-util", "macros"] }
 # Stream utils
-tokio-util = { version = "0.7.8", features = ["io"], optional = true }
+tokio-util = { version = "0.7", features = ["io"], optional = true }
 # Builders for method parameters
-typed-builder = { version = "0.14" }
+typed-builder = "0.18"
 
 [dev-dependencies]
 # Basic logger
 env_logger = "0.10.1"
 # Enable all features
-tokio = { version = "1.34", features = ["full"] }
+tokio = { version = "1.35.1", features = ["full"] }
 # HTTP client testing
-wiremock = "0.5.21"
+wiremock = "0.5.22"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 ```
-To run this program, set the `DATABENTO_API_KEY` environment variable with an actual API key.
+To run this program, set the `DATABENTO_API_KEY` environment variable with an API key.
 
 ### Historical
 
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 ```
 
-To run this program, set the `DATABENTO_API_KEY` environment variable with an actual API key.
+To run this program, set the `DATABENTO_API_KEY` environment variable with an API key.
 
 ## Documentation
 

--- a/src/historical/mod.rs
+++ b/src/historical/mod.rs
@@ -22,13 +22,16 @@ pub enum HistoricalGateway {
     Bo1,
 }
 
-/// A date range query. It can either be closed, or use
-/// forward fill behavior.
+// TODO(carter): update doc comment after refactor
+/// A date range query. It can either be half-closed, or use forward fill behavior.
+///
+/// Note: This enum will be reworked in the future.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DateRange {
     /// An interval where `end` is unspecified.
     Open(time::Date),
-    /// A closed interval with an inclusive start date and an exclusive end date.
+    /// A **half**-closed interval with an inclusive start date and an exclusive end
+    /// date.
     Closed {
         /// The start date (inclusive).
         start: time::Date,
@@ -37,17 +40,20 @@ pub enum DateRange {
     },
 }
 
-/// A date time range query. It can either be closed, or use
-/// forward fill behavior.
+// TODO(carter): update doc comment after refactor
+/// A date time range query. It can either be half-closed, or use forward fill behavior.
+///
+/// Note: This enum will be reworked in the future.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DateTimeRange {
     /// An interval where `end` is implied.
     FwdFill(time::OffsetDateTime),
-    /// A closed interval with an inclusive start time and an exclusive end time.
+    /// A **half**-closed interval with an inclusive start time and an exclusive end
+    /// time.
     Closed {
         /// The start date time (inclusive).
         start: time::OffsetDateTime,
-        /// The end date time (inclusive).
+        /// The end date time (exclusive).
         end: time::OffsetDateTime,
     },
 }


### PR DESCRIPTION
## 0.6.0 - 2024-01-16

#### Enhancements
- Relaxed version requirements for `tokio`, `tokio-util`, and `thiserror`

#### Breaking changes
- Updated DBN version to 0.15.0
  - Added support for larger `SystemMsg` and `ErrorMsg` records
  - Improved `Debug` implementations for records and `RecordRef`
  - Improved panic messages for `RecordRef::get`
- Upgraded `typed-builder` to 0.18
