### PR TITLE
VER: Release 0.7.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Cargo setup
       - name: Set up Cargo cache
         uses: actions/cache@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.0 - TBD
+
+### Breaking changes
+- Changed default `upgrade_policy` in `LiveBuilder` and `GetRangeParams` to `Upgrade` so
+  by default the primary record types can always be used
+
 ## 0.6.0 - 2024-01-16
 
 #### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,4 +132,4 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
   - Removed `mode` and `schema` parameters
 
 ## 0.1.0 - 2023-08-02
-- Initial release with support for historial and live data
+- Initial release with support for historical and live data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 #### Enhancements
 - Document cancellation safety of `LiveClient` methods (credit: @yongqli)
+- Document `live::Subscription::start` is based on `ts_event`
 
-### Breaking changes
+#### Breaking changes
 - Changed default `upgrade_policy` in `LiveBuilder` and `GetRangeParams` to `Upgrade` so
   by default the primary record types can always be used
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Document cancellation safety of `LiveClient` methods (credit: @yongqli)
 - Document `live::Subscription::start` is based on `ts_event`
 - Allow constructing a `DateRange` and `DateTimeRange` with an `end` based on a `time::Duration`
+- Implemented `Debug` for `LiveClient`, `LiveClientBuilder`, `HistoricalClient`,
+  `HistoricalClientBuilder`, `BatchClient`, `MetadataClient`, `SymbologyClient`, and
+  `TimeseriesClient`
+- Derived `Clone` for `LiveClientBuilder` and `HistoricalClientBuilder`
+- Added `ApiKey` type for safely deriving `Debug` for types containing an API key
 
 #### Breaking changes
 - Changed default `upgrade_policy` in `LiveBuilder` and `GetRangeParams` to `Upgrade` so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.7.0 - TBD
 
+#### Enhancements
+- Document cancellation safety of `LiveClient` methods (credit: @yongqli)
+
 ### Breaking changes
 - Changed default `upgrade_policy` in `LiveBuilder` and `GetRangeParams` to `Upgrade` so
   by default the primary record types can always be used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 #### Enhancements
 - Document cancellation safety of `LiveClient` methods (credit: @yongqli)
 - Document `live::Subscription::start` is based on `ts_event`
+- Allow constructing a `DateRange` and `DateTimeRange` with an `end` based on a `time::Duration`
 
 #### Breaking changes
 - Changed default `upgrade_policy` in `LiveBuilder` and `GetRangeParams` to `Upgrade` so
   by default the primary record types can always be used
+- Simplify `DateRange` and `DateTimeRange` by removing `FwdFill` variant that didn't work correctly
 
 ## 0.6.0 - 2024-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## 0.7.0 - TBD
+## 0.7.0 - 2024-03-01
 
 #### Enhancements
 - Document cancellation safety of `LiveClient` methods (credit: @yongqli)
 - Document `live::Subscription::start` is based on `ts_event`
-- Allow constructing a `DateRange` and `DateTimeRange` with an `end` based on a `time::Duration`
+- Allow constructing a `DateRange` and `DateTimeRange` with an `end` based on a
+  `time::Duration`
 - Implemented `Debug` for `LiveClient`, `LiveClientBuilder`, `HistoricalClient`,
   `HistoricalClientBuilder`, `BatchClient`, `MetadataClient`, `SymbologyClient`, and
   `TimeseriesClient`
@@ -15,7 +16,12 @@
 #### Breaking changes
 - Changed default `upgrade_policy` in `LiveBuilder` and `GetRangeParams` to `Upgrade` so
   by default the primary record types can always be used
-- Simplify `DateRange` and `DateTimeRange` by removing `FwdFill` variant that didn't work correctly
+- Simplified `DateRange` and `DateTimeRange` by removing `FwdFill` variant that didn't
+  work correctly
+- Upgraded DBN version to 0.16.0
+  - Updated `StatusMsg` in preparation for status schema release
+  - Fixed handling of `ts_out` when upgrading DBNv1 records to version 2
+  - Fixed handling of `ErrorMsgV1` and `SystemMsgV1` in `rtype` dispatch macros
 
 ## 0.6.0 - 2024-01-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -24,7 +24,7 @@ live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
 # binary encoding
-dbn = { version = "0.15.0", features = ["async", "serde"] }
+dbn = { version = "0.16.0", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Hex encoding used for Live authentication
@@ -53,6 +53,6 @@ typed-builder = "0.18"
 # Basic logger
 env_logger = "0.11.2"
 # Enable all features
-tokio = { version = "1.35.1", features = ["full"] }
+tokio = { version = "1.36", features = ["full"] }
 # HTTP client testing
-wiremock = "0.5.22"
+wiremock = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ typed-builder = "0.18"
 
 [dev-dependencies]
 # Basic logger
-env_logger = "0.10.1"
+env_logger = "0.11.2"
 # Enable all features
 tokio = { version = "1.35.1", features = ["full"] }
 # HTTP client testing

--- a/src/historical/batch.rs
+++ b/src/historical/batch.rs
@@ -679,36 +679,38 @@ mod tests {
             // // default
             .and(body_contains("stype_in", "raw_symbol"))
             .and(body_contains("stype_out", "instrument_id"))
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_json(json!({
-                "id": "123",
-                "user_id": "test_user",
-                "bill_id": "345",
-                "cost_usd": 10.50,
-                "dataset": "XNAS.ITCH",
-                "symbols": ["TSLA"],
-                "stype_in": "raw_symbol",
-                "stype_out": "instrument_id",
-                "schema": SCHEMA.as_str(),
-                "start": "2023-06-14T00:00:00.000000000Z",
-                "end": "2023-06-17 00:00:00.000000+00:00",
-                "limit": null,
-                "encoding": "dbn",
-                "compression": "zstd",
-                "pretty_px": false,
-                "pretty_ts": false,
-                "map_symbols": false,
-                "split_symbols": false,
-                "split_duration": "day",
-                "split_size": null,
-                "packaging": null,
-                "delivery": "download",
-                "state": "queued",
-                 "ts_received": "2023-07-19T23:00:04.095538123Z",
-                 "ts_queued": null,
-                 "ts_process_start": null,
-                 "ts_process_done": null,
-                 "ts_expiration": null
-            })))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK.as_u16()).set_body_json(json!({
+                    "id": "123",
+                    "user_id": "test_user",
+                    "bill_id": "345",
+                    "cost_usd": 10.50,
+                    "dataset": "XNAS.ITCH",
+                    "symbols": ["TSLA"],
+                    "stype_in": "raw_symbol",
+                    "stype_out": "instrument_id",
+                    "schema": SCHEMA.as_str(),
+                    "start": "2023-06-14T00:00:00.000000000Z",
+                    "end": "2023-06-17 00:00:00.000000+00:00",
+                    "limit": null,
+                    "encoding": "dbn",
+                    "compression": "zstd",
+                    "pretty_px": false,
+                    "pretty_ts": false,
+                    "map_symbols": false,
+                    "split_symbols": false,
+                    "split_duration": "day",
+                    "split_size": null,
+                    "packaging": null,
+                    "delivery": "download",
+                    "state": "queued",
+                     "ts_received": "2023-07-19T23:00:04.095538123Z",
+                     "ts_queued": null,
+                     "ts_process_start": null,
+                     "ts_process_done": null,
+                     "ts_expiration": null
+                })),
+            )
             .mount(&mock_server)
             .await;
         let mut target = HistoricalClient::with_url(
@@ -741,37 +743,39 @@ mod tests {
             .and(path(format!("/v{API_VERSION}/batch.list_jobs")))
             .and(query_param_is_missing("states"))
             .and(query_param_is_missing("since"))
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_json(json!([{
-                "id": "123",
-                "user_id": "test_user",
-                "bill_id": "345",
-                "cost_usd": 10.50,
-                "dataset": "XNAS.ITCH",
-                "symbols": "TSLA",
-                "stype_in": "raw_symbol",
-                "stype_out": "instrument_id",
-                "schema": SCHEMA.as_str(),
-                // test both time formats
-                "start": "2023-06-14 00:00:00+00:00",
-                "end": "2023-06-17T00:00:00.012345678Z",
-                "limit": null,
-                "encoding": "json",
-                "compression": "zstd",
-                "pretty_px": true,
-                "pretty_ts": false,
-                "map_symbols": true,
-                "split_symbols": false,
-                "split_duration": "day",
-                "split_size": null,
-                "packaging": null,
-                "delivery": "download",
-                "state": "processing",
-                 "ts_received": "2023-07-19 23:00:04.095538+00:00",
-                 "ts_queued": "2023-07-19T23:00:08.095538123Z",
-                 "ts_process_start": "2023-07-19 23:01:04.000000+00:00",
-                 "ts_process_done": null,
-                 "ts_expiration": null
-            }])))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK.as_u16()).set_body_json(json!([{
+                    "id": "123",
+                    "user_id": "test_user",
+                    "bill_id": "345",
+                    "cost_usd": 10.50,
+                    "dataset": "XNAS.ITCH",
+                    "symbols": "TSLA",
+                    "stype_in": "raw_symbol",
+                    "stype_out": "instrument_id",
+                    "schema": SCHEMA.as_str(),
+                    // test both time formats
+                    "start": "2023-06-14 00:00:00+00:00",
+                    "end": "2023-06-17T00:00:00.012345678Z",
+                    "limit": null,
+                    "encoding": "json",
+                    "compression": "zstd",
+                    "pretty_px": true,
+                    "pretty_ts": false,
+                    "map_symbols": true,
+                    "split_symbols": false,
+                    "split_duration": "day",
+                    "split_size": null,
+                    "packaging": null,
+                    "delivery": "download",
+                    "state": "processing",
+                     "ts_received": "2023-07-19 23:00:04.095538+00:00",
+                     "ts_queued": "2023-07-19T23:00:08.095538123Z",
+                     "ts_process_start": "2023-07-19 23:01:04.000000+00:00",
+                     "ts_process_done": null,
+                     "ts_expiration": null
+                }])),
+            )
             .mount(&mock_server)
             .await;
         let mut target = HistoricalClient::with_url(

--- a/src/historical/batch.rs
+++ b/src/historical/batch.rs
@@ -23,6 +23,7 @@ use crate::{historical::check_http_error, Error, Symbols};
 use super::{handle_response, DateTimeRange};
 
 /// A client for the batch group of Historical API endpoints.
+#[derive(Debug)]
 pub struct BatchClient<'a> {
     pub(crate) inner: &'a mut super::Client,
 }

--- a/src/historical/metadata.rs
+++ b/src/historical/metadata.rs
@@ -426,7 +426,7 @@ mod tests {
     use serde_json::json;
     use time::macros::date;
     use wiremock::{
-        matchers::{basic_auth, method, path, query_param, query_param_is_missing},
+        matchers::{basic_auth, method, path, query_param},
         Mock, MockServer, ResponseTemplate,
     };
 
@@ -566,7 +566,7 @@ mod tests {
             )))
             .and(query_param("dataset", DATASET))
             .and(query_param("start_date", "2022-05-17"))
-            .and(query_param_is_missing("end_date"))
+            .and(query_param("end_date", "2022-05-18"))
             .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_json(json!([
                 {
                     "date": "2022-05-17",
@@ -592,7 +592,7 @@ mod tests {
             .get_dataset_condition(
                 &GetDatasetConditionParams::builder()
                     .dataset(DATASET.to_owned())
-                    .date_range(date!(2022 - 05 - 17))
+                    .date_range((date!(2022 - 05 - 17), time::Duration::DAY))
                     .build(),
             )
             .await

--- a/src/historical/metadata.rs
+++ b/src/historical/metadata.rs
@@ -449,15 +449,17 @@ mod tests {
             .and(path(format!("/v{API_VERSION}/metadata.list_fields")))
             .and(query_param("encoding", ENC.as_str()))
             .and(query_param("schema", SCHEMA.as_str()))
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_json(json!([
-                {"name":"ts_event", "type": "uint64_t"},
-                {"name":"rtype", "type": "uint8_t"},
-                {"name":"open", "type": "int64_t"},
-                {"name":"high", "type": "int64_t"},
-                {"name":"low", "type": "int64_t"},
-                {"name":"close", "type": "int64_t"},
-                {"name":"volume", "type": "uint64_t"},
-            ])))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK.as_u16()).set_body_json(json!([
+                    {"name":"ts_event", "type": "uint64_t"},
+                    {"name":"rtype", "type": "uint8_t"},
+                    {"name":"open", "type": "int64_t"},
+                    {"name":"high", "type": "int64_t"},
+                    {"name":"low", "type": "int64_t"},
+                    {"name":"close", "type": "int64_t"},
+                    {"name":"volume", "type": "uint64_t"},
+                ])),
+            )
             .mount(&mock_server)
             .await;
         let mut target = HistoricalClient::with_url(
@@ -518,20 +520,22 @@ mod tests {
             .and(basic_auth(API_KEY, ""))
             .and(path(format!("/v{API_VERSION}/metadata.list_unit_prices")))
             .and(query_param("dataset", DATASET))
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_json(json!([
-                {
-                    "mode": "historical",
-                    "unit_prices": {
-                        SCHEMA.as_str(): 17.89
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK.as_u16()).set_body_json(json!([
+                    {
+                        "mode": "historical",
+                        "unit_prices": {
+                            SCHEMA.as_str(): 17.89
+                        }
+                    },
+                    {
+                        "mode": "live",
+                        "unit_prices": {
+                            SCHEMA.as_str(): 34.22
+                        }
                     }
-                },
-                {
-                    "mode": "live",
-                    "unit_prices": {
-                        SCHEMA.as_str(): 34.22
-                    }
-                }
-            ])))
+                ])),
+            )
             .mount(&mock_server)
             .await;
         let mut target = HistoricalClient::with_url(
@@ -568,18 +572,20 @@ mod tests {
             .and(query_param("dataset", DATASET))
             .and(query_param("start_date", "2022-05-17"))
             .and(query_param("end_date", "2022-05-18"))
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_json(json!([
-                {
-                    "date": "2022-05-17",
-                    "condition": "available",
-                    "last_modified_date": "2023-07-11",
-                },
-                {
-                    "date": "2022-05-18",
-                    "condition": "degraded",
-                    "last_modified_date": "2022-05-19",
-                }
-            ])))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK.as_u16()).set_body_json(json!([
+                    {
+                        "date": "2022-05-17",
+                        "condition": "available",
+                        "last_modified_date": "2023-07-11",
+                    },
+                    {
+                        "date": "2022-05-18",
+                        "condition": "degraded",
+                        "last_modified_date": "2022-05-19",
+                    }
+                ])),
+            )
             .mount(&mock_server)
             .await;
         let mut target = HistoricalClient::with_url(
@@ -625,10 +631,12 @@ mod tests {
             .and(basic_auth(API_KEY, ""))
             .and(path(format!("/v{API_VERSION}/metadata.get_dataset_range")))
             .and(query_param("dataset", DATASET))
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_json(json!({
-                "start_date": "2019-07-07",
-                "end_date": "2023-07-19",
-            })))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK.as_u16()).set_body_json(json!({
+                    "start_date": "2019-07-07",
+                    "end_date": "2023-07-19",
+                })),
+            )
             .mount(&mock_server)
             .await;
         let mut target = HistoricalClient::with_url(

--- a/src/historical/metadata.rs
+++ b/src/historical/metadata.rs
@@ -12,6 +12,7 @@ use crate::Symbols;
 use super::{handle_response, AddToQuery, DateRange, DateTimeRange};
 
 /// A client for the metadata group of Historical API endpoints.
+#[derive(Debug)]
 pub struct MetadataClient<'a> {
     pub(crate) inner: &'a mut super::Client,
 }

--- a/src/historical/symbology.rs
+++ b/src/historical/symbology.rs
@@ -12,6 +12,7 @@ use crate::Symbols;
 use super::{handle_response, DateRange};
 
 /// A client for the symbology group of Historical API endpoints.
+#[derive(Debug)]
 pub struct SymbologyClient<'a> {
     pub(crate) inner: &'a mut super::Client,
 }

--- a/src/historical/symbology.rs
+++ b/src/historical/symbology.rs
@@ -178,24 +178,26 @@ mod tests {
             .and(body_contains("stype_out", "instrument_id"))
             .and(body_contains("start_date", "2023-06-14"))
             .and(body_contains("end_date", "2023-06-17"))
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_json(json!({
-                "result": {
-                    "ES.c.0": [
-                        {
-                            "d0": "2023-06-14",
-                            "d1": "2023-06-15",
-                            "s": "10245"
-                        },
-                        {
-                            "d0": "2023-06-15",
-                            "d1": "2023-06-16",
-                            "s": "10248"
-                        }
-                    ]
-                },
-                "partial": [],
-                "not_found": ["ES.d.0"]
-            })))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK.as_u16()).set_body_json(json!({
+                    "result": {
+                        "ES.c.0": [
+                            {
+                                "d0": "2023-06-14",
+                                "d1": "2023-06-15",
+                                "s": "10245"
+                            },
+                            {
+                                "d0": "2023-06-15",
+                                "d1": "2023-06-16",
+                                "s": "10248"
+                            }
+                        ]
+                    },
+                    "partial": [],
+                    "not_found": ["ES.d.0"]
+                })),
+            )
             .mount(&mock_server)
             .await;
         let mut target = HistoricalClient::with_url(

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -142,7 +142,7 @@ mod tests {
             // // default
             .and(body_contains("stype_in", "raw_symbol"))
             .and(body_contains("stype_out", "instrument_id"))
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_bytes(bytes))
+            .respond_with(ResponseTemplate::new(StatusCode::OK.as_u16()).set_body_bytes(bytes))
             .mount(&mock_server)
             .await;
         let mut target = HistoricalClient::with_url(

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -16,6 +16,7 @@ use super::{check_http_error, DateTimeRange};
 pub use dbn::decode::AsyncDbnDecoder;
 
 /// A client for the timeseries group of Historical API endpoints.
+#[derive(Debug)]
 pub struct TimeseriesClient<'a> {
     pub(crate) inner: &'a mut super::Client,
 }

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -95,8 +95,8 @@ pub struct GetRangeParams {
     /// The optional maximum number of records to return. Defaults to no limit.
     #[builder(default)]
     pub limit: Option<NonZeroU64>,
-    /// How to decode DBN from prior versions. Defaults to as-is.
-    #[builder(default)]
+    /// How to decode DBN from prior versions. Defaults to upgrade.
+    #[builder(default = VersionUpgradePolicy::Upgrade)]
     pub upgrade_policy: VersionUpgradePolicy,
 }
 

--- a/src/live.rs
+++ b/src/live.rs
@@ -330,7 +330,7 @@ impl Default for ClientBuilder<Unset, Unset> {
             key: Unset,
             dataset: Unset,
             send_ts_out: false,
-            upgrade_policy: VersionUpgradePolicy::AsIs,
+            upgrade_policy: VersionUpgradePolicy::Upgrade,
         }
     }
 }

--- a/src/live.rs
+++ b/src/live.rs
@@ -317,8 +317,8 @@ pub struct Subscription {
     /// The symbology type of the symbols in [`symbols`](Self::symbols).
     #[builder(default = SType::RawSymbol)]
     pub stype_in: SType,
-    /// If specified, requests available data since that time. When `None`,
-    /// only real-time data is sent.
+    /// If specified, requests available data since that time (inclusive), based on
+    /// [`ts_event`](dbn::RecordHeader::ts_event). When `None`, only real-time data is sent.
     ///
     /// Setting this field is not supported once the session has been started with
     /// [`LiveClient::start`](crate::LiveClient::start).

--- a/src/live.rs
+++ b/src/live.rs
@@ -91,8 +91,13 @@ impl Client {
             connection: writer,
             // Pass a placeholder DBN version and should never fail because DBN_VERSION
             // is a valid DBN version. Correct version set in `start()`.
-            decoder: AsyncRecordDecoder::with_version(reader, dbn::DBN_VERSION, upgrade_policy)
-                .unwrap(),
+            decoder: AsyncRecordDecoder::with_version(
+                reader,
+                dbn::DBN_VERSION,
+                upgrade_policy,
+                send_ts_out,
+            )
+            .unwrap(),
             session_id,
         })
     }
@@ -282,6 +287,8 @@ impl Client {
             .decode()
             .await?;
         self.decoder.set_version(metadata.version)?;
+        // Should match `send_ts_out` but set again here for safety
+        self.decoder.set_ts_out(metadata.ts_out);
         metadata.upgrade(self.upgrade_policy);
         Ok(metadata)
     }


### PR DESCRIPTION
#### Enhancements
- Document cancellation safety of `LiveClient` methods (credit: @yongqli)
- Document `live::Subscription::start` is based on `ts_event`
- Allow constructing a `DateRange` and `DateTimeRange` with an `end` based on a `time::Duration`
- Implemented `Debug` for `LiveClient`, `LiveClientBuilder`, `HistoricalClient`,
  `HistoricalClientBuilder`, `BatchClient`, `MetadataClient`, `SymbologyClient`, and
  `TimeseriesClient`
- Derived `Clone` for `LiveClientBuilder` and `HistoricalClientBuilder`
- Added `ApiKey` type for safely deriving `Debug` for types containing an API key

#### Breaking changes
- Changed default `upgrade_policy` in `LiveBuilder` and `GetRangeParams` to `Upgrade` so
  by default the primary record types can always be used
- Simplify `DateRange` and `DateTimeRange` by removing `FwdFill` variant that didn't work correctly