### PR TITLE
VER: Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.2 - TBD
+
+#### Enhancements
+- Added `use_snapshot` attribute to `Subscription`, defaults to false
+
 ## 0.9.1 - 2024-05-15
 
 #### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
 # Changelog
 
-## 0.9.2 - TBD
+## 0.10.0 - 2024-05-22
 
 #### Enhancements
 - Added `use_snapshot` attribute to `Subscription`, defaults to false
+- Upgraded reqwest version to 0.12
+
+#### Breaking changes
+- Upgraded DBN version to 0.18.0
+  - Changed type of `flags` in `MboMsg`, `TradeMsg`, `Mbp1Msg`, `Mbp10Msg`, and `CbboMsg`
+    from `u8` to a new `FlagSet` type with predicate methods   for the various bit flags
+    as well as setters. The `u8` value can still be obtained by calling the `raw()` method.
+    - Improved `Debug` formatting
+  - Switched `DecodeStream` from `streaming_iterator` crate to `fallible_streaming_iterator`
+    to allow better notification of errors
+  - Changed default value for `stype_in` and `stype_out` in `SymbolMappingMsg` to
+    `u8::MAX` to match C++ client and to reflect an unknown value. This also changes the
+    value of these fields when upgrading a `SymbolMappingMsgV1` to DBNv2
 
 ## 0.9.1 - 2024-05-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -24,14 +24,14 @@ live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
 # binary encoding
-dbn = { version = "0.17.1", features = ["async", "serde"] }
+dbn = { version = "0.18.0", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication
 hex = { version = "0.4", optional = true }
 log = "0.4"
 # HTTP client for historical API
-reqwest = { version = "0.11", optional = true, features = ["json", "stream"] }
+reqwest = { version = "0.12", optional = true, features = ["json", "stream"] }
 # JSON deserialization for historical API
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }

--- a/src/live.rs
+++ b/src/live.rs
@@ -27,6 +27,10 @@ pub struct Subscription {
     /// [`LiveClient::start`](crate::LiveClient::start).
     #[builder(default, setter(strip_option))]
     pub start: Option<OffsetDateTime>,
+    #[doc(hidden)]
+    /// Reserved for future use.
+    #[builder(setter(strip_bool))]
+    pub use_snapshot: bool,
 }
 
 #[doc(hidden)]

--- a/src/live/client.rs
+++ b/src/live/client.rs
@@ -346,7 +346,7 @@ mod tests {
         enums::rtype,
         publishers::Dataset,
         record::{HasRType, OhlcvMsg, RecordHeader, TradeMsg, WithTsOut},
-        Mbp10Msg, MetadataBuilder, Record, SType, Schema,
+        FlagSet, Mbp10Msg, MetadataBuilder, Record, SType, Schema,
     };
     use tokio::{
         io::BufReader,
@@ -670,7 +670,7 @@ mod tests {
                 size: 2,
                 action: b'A' as c_char,
                 side: b'A' as c_char,
-                flags: 0,
+                flags: FlagSet::default(),
                 depth: 1,
                 ts_recv: 0,
                 ts_in_delta: 0,


### PR DESCRIPTION
#### Enhancements
- Added `use_snapshot` attribute to `Subscription`, defaults to false
- Upgraded reqwest version to 0.12

#### Breaking changes
- Upgraded DBN version to 0.18.0
  - Changed type of `flags` in `MboMsg`, `TradeMsg`, `Mbp1Msg`, `Mbp10Msg`, and `CbboMsg`
    from `u8` to a new `FlagSet` type with predicate methods   for the various bit flags
    as well as setters. The `u8` value can still be obtained by calling the `raw()` method.
    - Improved `Debug` formatting
  - Switched `DecodeStream` from `streaming_iterator` crate to `fallible_streaming_iterator`
    to allow better notification of errors
  - Changed default value for `stype_in` and `stype_out` in `SymbolMappingMsg` to
    `u8::MAX` to match C++ client and to reflect an unknown value. This also changes the
    value of these fields when upgrading a `SymbolMappingMsgV1` to DBNv2