### PR TITLE
VER: Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### Breaking changes
 - Added `heartbeat_interval` parameter to `LiveClient::connect` and
   `LiveClient::connect_with_addr`
+- Removed deprecated `start_date` and `end_date` fields from `DatasetRange` struct
 
 ## 0.10.0 - 2024-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.11.0 - TBD
+
+#### Enhancements
+- Added configurable `heartbeat_interval` parameter for live client that determines the
+  timeout before heartbeat `SystemMsg` records will be sent. It can be configured via
+  the `heartbeat_interval` and `heartbeat_interval_s` methods of the
+  `live::ClientBuilder`
+- Added `addr` function to `live::ClientBuilder` for configuring a custom gateway
+  address without using `LiveClient::connect_with_addr` directly
+
+#### Breaking changes
+- Added `heartbeat_interval` parameter to `LiveClient::connect` and
+  `LiveClient::connect_with_addr`
+
 ## 0.10.0 - 2024-05-22
 
 #### Enhancements
@@ -56,10 +70,10 @@
 - Document `live::Subscription::start` is based on `ts_event`
 - Allow constructing a `DateRange` and `DateTimeRange` with an `end` based on a
   `time::Duration`
-- Implemented `Debug` for `LiveClient`, `LiveClientBuilder`, `HistoricalClient`,
-  `HistoricalClientBuilder`, `BatchClient`, `MetadataClient`, `SymbologyClient`, and
+- Implemented `Debug` for `LiveClient`, `live::ClientBuilder`, `HistoricalClient`,
+  `historical::ClientBuilder`, `BatchClient`, `MetadataClient`, `SymbologyClient`, and
   `TimeseriesClient`
-- Derived `Clone` for `LiveClientBuilder` and `HistoricalClientBuilder`
+- Derived `Clone` for `live::ClientBuilder` and `historical::ClientBuilder`
 - Added `ApiKey` type for safely deriving `Debug` for types containing an API key
 
 #### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.11.0 - TBD
+## 0.11.0 - 2024-06-04
 
 #### Enhancements
 - Added configurable `heartbeat_interval` parameter for live client that determines the
@@ -9,6 +9,7 @@
   `live::ClientBuilder`
 - Added `addr` function to `live::ClientBuilder` for configuring a custom gateway
   address without using `LiveClient::connect_with_addr` directly
+- Upgraded DBN version to 0.18.1
 
 #### Breaking changes
 - Added `heartbeat_interval` parameter to `LiveClient::connect` and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -24,7 +24,7 @@ live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
 # binary encoding
-dbn = { version = "0.18.0", features = ["async", "serde"] }
+dbn = { version = "0.18.1", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication
@@ -39,12 +39,12 @@ serde_json = { version = "1.0", optional = true }
 sha2 = { version = "0.10", optional = true }
 thiserror = "1.0"
 time = { version = ">=0.3.35", features = ["macros", "parsing", "serde"] }
-tokio = { version = "1", features = ["io-util", "macros"] }
+tokio = { version = ">=1.28", features = ["io-util", "macros"] }
 # Stream utils
 tokio-util = { version = "0.7", features = ["io"], optional = true }
 typed-builder = "0.18"
 
 [dev-dependencies]
 env_logger = "0.11.2"
-tokio = { version = "1.36", features = ["full"] }
+tokio = { version = "1.38", features = ["full"] }
 wiremock = "0.6"

--- a/src/historical/metadata.rs
+++ b/src/historical/metadata.rs
@@ -278,14 +278,8 @@ pub struct DatasetConditionDetail {
 pub struct DatasetRange {
     /// The start of the available range.
     pub start: time::OffsetDateTime,
-    /// The start date of the available range.
-    #[deprecated(since = "0.9.0", note = "Use `start` instead.")]
-    pub start_date: time::Date,
     /// The end of the available range (exclusive).
     pub end: time::OffsetDateTime,
-    /// The end date of the available range (inclusive).
-    #[deprecated(since = "0.9.0", note = "Use `end` instead.")]
-    pub end_date: time::Date,
 }
 
 #[allow(deprecated)]
@@ -305,9 +299,7 @@ impl<'de> Deserialize<'de> for DatasetRange {
 
         Ok(DatasetRange {
             start: partial.start,
-            start_date: partial.start.date(),
             end: partial.end,
-            end_date: (partial.end - time::Duration::days(1)).date(),
         })
     }
 }
@@ -665,10 +657,8 @@ mod tests {
             .respond_with(
                 ResponseTemplate::new(StatusCode::OK.as_u16()).set_body_json(json!({
                     "start": "2019-07-07T00:00:00.000000000Z",
-                    "start_date": "2019-07-07",
                     // test both time formats
                     "end": "2023-07-20T00:00:00.000000000Z",
-                    "end_date": "2023-07-19",
                 })),
             )
             .mount(&mock_server)
@@ -681,9 +671,7 @@ mod tests {
         .unwrap();
         let range = target.metadata().get_dataset_range(DATASET).await.unwrap();
         assert_eq!(range.start, datetime!(2019 - 07 - 07 00:00:00+00:00));
-        assert_eq!(range.start_date, date!(2019 - 07 - 07));
         assert_eq!(range.end, datetime!(2023 - 07 - 20 00:00:00.000000+00:00));
-        assert_eq!(range.end_date, date!(2023 - 07 - 19));
     }
 
     #[tokio::test]
@@ -711,8 +699,6 @@ mod tests {
         .unwrap();
         let range = target.metadata().get_dataset_range(DATASET).await.unwrap();
         assert_eq!(range.start, datetime!(2019 - 07 - 07 00:00:00+00:00));
-        assert_eq!(range.start_date, date!(2019 - 07 - 07));
         assert_eq!(range.end, datetime!(2023 - 07 - 20 00:00:00.000000+00:00));
-        assert_eq!(range.end_date, date!(2023 - 07 - 19));
     }
 }


### PR DESCRIPTION
##### Enhancements
- Added configurable `heartbeat_interval` parameter for live client that determines the
  timeout before heartbeat `SystemMsg` records will be sent. It can be configured via
  the `heartbeat_interval` and `heartbeat_interval_s` methods of the
  `live::ClientBuilder`
- Added `addr` function to `live::ClientBuilder` for configuring a custom gateway
  address without using `LiveClient::connect_with_addr` directly
- Upgraded DBN version to 0.18.1

##### Breaking changes
- Added `heartbeat_interval` parameter to `LiveClient::connect` and
  `LiveClient::connect_with_addr`