### PR TITLE
VER: Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.0 - TBD
+
+#### Deprecations
+- Deprecated `Packaging::Tar`. Users should switch to `Packaging::Zip`. This variant
+  will be removed in a future version when it is no longer supported by the API
+
 ## 0.12.1 - 2024-08-27
 
 #### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.13.0 - TBD
+## 0.13.0 - 2024-09-24
+
+#### Enhancements
+- Upgraded DBN version to 0.21.0 for:
+  - Changed the layout of `CbboMsg` to better match `BboMsg`
+  - Renamed `Schema::Cbbo` to `Schema::Cmbp1`
+- Upgraded `typed-builder` version to 0.20
 
 #### Deprecations
 - Deprecated `Packaging::Tar`. Users should switch to `Packaging::Zip`. This variant

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -24,7 +24,7 @@ live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
 # binary encoding
-dbn = { version = "0.20.1", features = ["async", "serde"] }
+dbn = { version = "0.21.0", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication
@@ -42,12 +42,12 @@ time = { version = ">=0.3.35", features = ["macros", "parsing", "serde"] }
 tokio = { version = ">=1.28", features = ["io-util", "macros"] }
 # Stream utils
 tokio-util = { version = "0.7", features = ["io"], optional = true }
-typed-builder = "0.18"
+typed-builder = "0.20"
 
 [dev-dependencies]
-anyhow = "1.0.86"
-clap = { version = "4.5.1", features = ["derive"] }
-env_logger = "0.11.3"
-tempfile = "3.10.1"
-tokio = { version = "1.38", features = ["full"] }
+anyhow = "1.0.89"
+clap = { version = "4.5.18", features = ["derive"] }
+env_logger = "0.11.5"
+tempfile = "3.12.0"
+tokio = { version = "1.40", features = ["full"] }
 wiremock = "0.6"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://img.shields.io/docsrs/databento)](https://docs.rs/databento/latest/databento/)
 [![license](https://img.shields.io/github/license/databento/databento-rs?color=blue)](./LICENSE)
 [![Current Crates.io Version](https://img.shields.io/crates/v/databento.svg)](https://crates.io/crates/databento)
-[![Slack](https://img.shields.io/badge/join_Slack-community-darkblue.svg?logo=slack)](https://join.slack.com/t/databento-hq/shared_invite/zt-24oqyrub9-MellISM2cdpQ7s_7wcXosw)
+[![Slack](https://img.shields.io/badge/join_Slack-community-darkblue.svg?logo=slack)](https://join.slack.com/t/databento-hq/shared_invite/zt-1ryj8bb50-aASfjMVzoFbABHauQ335zg)
 
 The official Rust client library for [Databento](https://databento.com).
 The clients support fast and safe streaming of both real-time and historical market data

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://img.shields.io/docsrs/databento)](https://docs.rs/databento/latest/databento/)
 [![license](https://img.shields.io/github/license/databento/databento-rs?color=blue)](./LICENSE)
 [![Current Crates.io Version](https://img.shields.io/crates/v/databento.svg)](https://crates.io/crates/databento)
-[![Slack](https://img.shields.io/badge/join_Slack-community-darkblue.svg?logo=slack)](https://join.slack.com/t/databento-hq/shared_invite/zt-1ryj8bb50-aASfjMVzoFbABHauQ335zg)
+[![Slack](https://img.shields.io/badge/join_Slack-community-darkblue.svg?logo=slack)](https://to.dbn.to/slack)
 
 The official Rust client library for [Databento](https://databento.com).
 The clients support fast and safe streaming of both real-time and historical market data

--- a/src/historical/batch.rs
+++ b/src/historical/batch.rs
@@ -285,7 +285,7 @@ pub struct SubmitJobParams {
     #[builder(default)]
     pub split_duration: SplitDuration,
     /// The optional maximum size (in bytes) of each batched data file before being split.
-    /// Defaults to `None`.
+    /// Must be an integer between 1e9 and 10e9 inclusive (1GB - 10GB). Defaults to `None`.
     #[builder(default, setter(strip_option))]
     pub split_size: Option<NonZeroU64>,
     /// The optional archive type to package all batched data files in. Defaults to `None`.

--- a/src/historical/batch.rs
+++ b/src/historical/batch.rs
@@ -213,6 +213,7 @@ pub enum Packaging {
     /// ZIP compressed.
     Zip,
     /// Tarball.
+    #[deprecated(since = "0.13.0", note = "Users should use Zip instead")]
     Tar,
 }
 
@@ -475,6 +476,7 @@ impl Packaging {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Packaging::Zip => "zip",
+            #[allow(deprecated)]
             Packaging::Tar => "tar",
         }
     }
@@ -492,6 +494,7 @@ impl FromStr for Packaging {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "zip" => Ok(Packaging::Zip),
+            #[allow(deprecated)]
             "tar" => Ok(Packaging::Tar),
             _ => Err(crate::Error::bad_arg(
                 "s",


### PR DESCRIPTION
#### Enhancements
- Upgraded DBN version to 0.21.0 for:
  - Changed the layout of `CbboMsg` to better match `BboMsg`
  - Renamed `Schema::Cbbo` to `Schema::Cmbp1`
- Upgraded `typed-builder` version to 0.20

#### Deprecations
- Deprecated `Packaging::Tar`. Users should switch to `Packaging::Zip`. This variant
  will be removed in a future version when it is no longer supported by the API