### PR TITLE
VER: Release 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.18.1 - TBD
+
+### Bug fixes
+- Changed historical metadata methods with `symbols` parameter to use a `POST` request
+  to allow for requesting supported maximum of 2000 symbols
+
 ## 0.18.0 - 2025-01-08
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.18.1 - TBD
+## 0.19.0 - 2025-01-21
+
+### Enhancements
+- Upgraded DBN version to 0.27.0:
+  - Updated enumerations for unreleased US equities datasets and publishers
+  - Added new venue `EQUS` for consolidated US equities
+  - Added new dataset `EQUS.MINI` and new publishers `EQUS.MINI.EQUS` and
+    `XNYS.TRADES.EQUS`
 
 ### Bug fixes
 - Changed historical metadata methods with `symbols` parameter to use a `POST` request
@@ -21,7 +28,8 @@
     - Decoding streams: `MergeDecoder` and `MergeRecordDecoder` structs
     - Metadata: `MergeDecoder` struct and `Metadata::merge()` method
     - In the CLI: specify more than one input file to initiate a merge
-  - Eliminated `unsafe` in `From` implementations for record structs from different versions
+  - Eliminated `unsafe` in `From` implementations for record structs from different
+    versions
 
 ## 0.17.0 - 2024-12-17
 
@@ -53,8 +61,8 @@
 
 #### Deprecations
 - Deprecated `Packaging` enum and `packaging` field on `SubmitJobParams` and `BatchJob`.
-  These will be removed in a future version. All files from a batch job can be downloaded
-  with the `batch().download()` method on the historical client
+  These will be removed in a future version. All files from a batch job can be
+  downloaded with the `batch().download()` method on the historical client
 
 ## 0.15.0 - 2024-10-22
 
@@ -180,11 +188,13 @@
 ## 0.9.0 - 2024-05-14
 
 #### Enhancements
-- Added `start` and `end` fields to the `DatasetRange` struct which provide time resolution and an exclusive end date
+- Added `start` and `end` fields to the `DatasetRange` struct which provide time
+  resolution and an exclusive end date
 - Upgraded DBN version to 0.17.1
 
 #### Deprecations
-- The `start_date` and `end_date` fields of the `DatasetRange` struct are deprecated and will be removed in a future release
+- The `start_date` and `end_date` fields of the `DatasetRange` struct are deprecated and
+  will be removed in a future release
 
 ## 0.8.0 - 2024-04-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -23,7 +23,7 @@ historical = ["dep:futures", "dep:reqwest", "dep:serde", "dep:tokio-util", "dep:
 live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
-dbn = { version = "0.26.0", features = ["async", "serde"] }
+dbn = { version = "0.27.0", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication

--- a/src/live/client.rs
+++ b/src/live/client.rs
@@ -244,7 +244,6 @@ impl fmt::Debug for Client {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use std::{ffi::c_char, fmt};
 


### PR DESCRIPTION
### Enhancements
- Upgraded DBN version to 0.27.0:
  - Updated enumerations for unreleased US equities datasets and publishers
  - Added new venue `EQUS` for consolidated US equities
  - Added new dataset `EQUS.MINI` and new publishers `EQUS.MINI.EQUS` and
    `XNYS.TRADES.EQUS`

### Bug fixes
- Changed historical metadata methods with `symbols` parameter to use a `POST` request
  to allow for requesting supported maximum of 2000 symbols
