### PR TITLE
VER: Release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.22.0 - TBD
+- Added an implementation `From<Date>` for `DateRange` and `DateTimeRange` to make it
+  simpler to request a single full day's worth of data
+- Added conversions between `DateRange` and `DateTimeRange`
+- Added conversions from `timeseries::GetRangeParams`, `timeseries::GetRangeToFileParams`,
+  and `dbn::Metadata` to `symbology::ResolveParams`
+- Upgraded DBN version to 0.30.0:
+  - Added support for mapping symbols from instrument definitions to `PitSymbolMap`
+    with a new `on_instrument_def()` method
+  - Added instrument definition compatibility trait `InstrumentDefRec` for generalizing
+    across different versions of the instrument definition record
+
 ## 0.21.0 - 2025-03-18
 
 ### Enhancements
@@ -8,6 +20,14 @@
 - Improved error when calling `LiveClient::start()` on an instance that has already
   been started
 - Upgraded DBN version to 0.29.0:
+  - Added new venues, datasets, and publishers for ICE Futures US, ICE Futures Europe
+    (Financial products), Eurex, and European Energy Exchange (EEX)
+  - Added new `SkipBytes` and `AsyncSkipBytes` traits which are a subset of the `Seek`
+    and `AsyncSeek` traits respectively, only supporting seeking forward from the current
+    position
+  - Deprecated `AsyncRecordDecoder::get_mut()` and `AsyncDecoder::get_mut()` as modifying
+    the inner reader after decoding any records could lead to a corrupted stream and
+    decoding errors
 
 ## 0.20.0 - 2025-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,23 @@
 # Changelog
 
-## 0.22.0 - TBD
+## 0.22.0 - 2025-04-01
 - Added an implementation `From<Date>` for `DateRange` and `DateTimeRange` to make it
   simpler to request a single full day's worth of data
 - Added conversions between `DateRange` and `DateTimeRange`
 - Added conversions from `timeseries::GetRangeParams`, `timeseries::GetRangeToFileParams`,
   and `dbn::Metadata` to `symbology::ResolveParams`
-- Upgraded DBN version to 0.30.0:
+- Upgraded DBN version to 0.31.0:
   - Added support for mapping symbols from instrument definitions to `PitSymbolMap`
     with a new `on_instrument_def()` method
   - Added instrument definition compatibility trait `InstrumentDefRec` for generalizing
     across different versions of the instrument definition record
+  - Added `Ord` and `PartialOrd` implementations for all enums and `FlagSet` to allow
+    for use in ordered containers like `BTreeMap`
+  - Added `decode_records()` method to `AsyncDbnDecoder` and `AsyncDbnRecordDecoder`
+    which is similar to the sync decoder methods of the same name
+  - Removed deprecated `dataset` module. The top-level `Dataset` enum and its `const` `as_str()`
+    method provide the same functionality for all datasets
+  - Removed deprecated `SymbolIndex::get_for_rec_ref()` method
 
 ## 0.21.0 - 2025-03-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ historical = ["dep:futures", "dep:reqwest", "dep:serde", "dep:tokio-util", "dep:
 live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
-dbn = { version = "0.29.0", features = ["async", "serde"] }
+dbn = { version = "0.30.0", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication
@@ -39,13 +39,13 @@ tokio = { version = ">=1.28", features = ["io-util", "macros"] }
 # Stream utils
 tokio-util = { version = "0.7", features = ["io"], optional = true }
 tracing = "0.1"
-typed-builder = "0.20"
+typed-builder = "0.21"
 
 [dev-dependencies]
 anyhow = "1.0.97"
-async-compression = { version = "0.4.20", features = ["tokio", "zstd"] }
-clap = { version = "4.5.31", features = ["derive"] }
-tempfile = "3.17.1"
-tokio = { version = "1.43", features = ["full"] }
+async-compression = { version = "0.4.22", features = ["tokio", "zstd"] }
+clap = { version = "4.5.34", features = ["derive"] }
+tempfile = "3.19.1"
+tokio = { version = "1.44", features = ["full"] }
 tracing-subscriber = "0.3.19"
 wiremock = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -23,7 +23,7 @@ historical = ["dep:futures", "dep:reqwest", "dep:serde", "dep:tokio-util", "dep:
 live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
-dbn = { version = "0.30.0", features = ["async", "serde"] }
+dbn = { version = "0.31.0", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication
@@ -44,7 +44,7 @@ typed-builder = "0.21"
 [dev-dependencies]
 anyhow = "1.0.97"
 async-compression = { version = "0.4.22", features = ["tokio", "zstd"] }
-clap = { version = "4.5.34", features = ["derive"] }
+clap = { version = "4.5.35", features = ["derive"] }
 tempfile = "3.19.1"
 tokio = { version = "1.44", features = ["full"] }
 tracing-subscriber = "0.3.19"

--- a/src/historical.rs
+++ b/src/historical.rs
@@ -8,7 +8,9 @@ pub mod symbology;
 pub mod timeseries;
 
 pub use client::*;
-use time::{format_description::BorrowedFormatItem, macros::format_description};
+use time::{
+    format_description::BorrowedFormatItem, macros::format_description, Duration, Time, UtcOffset,
+};
 
 use crate::{Error, Symbols};
 
@@ -57,6 +59,49 @@ impl From<(time::Date, time::Duration)> for DateRange {
         Self {
             start: value.0,
             end: value.0 + value.1,
+        }
+    }
+}
+
+impl From<time::Date> for DateRange {
+    fn from(date: time::Date) -> Self {
+        Self {
+            start: date,
+            end: date.next_day().unwrap(),
+        }
+    }
+}
+
+impl From<time::Date> for DateTimeRange {
+    fn from(date: time::Date) -> Self {
+        let start = date.with_time(Time::MIDNIGHT).assume_utc();
+        Self {
+            start,
+            end: start + Duration::DAY,
+        }
+    }
+}
+
+impl From<DateRange> for DateTimeRange {
+    fn from(date_range: DateRange) -> Self {
+        Self {
+            start: date_range.start.with_time(Time::MIDNIGHT).assume_utc(),
+            end: date_range.end.with_time(Time::MIDNIGHT).assume_utc(),
+        }
+    }
+}
+
+impl From<DateTimeRange> for DateRange {
+    fn from(dt_range: DateTimeRange) -> Self {
+        let utc_end = dt_range.end.to_offset(UtcOffset::UTC);
+        Self {
+            start: dt_range.start.to_offset(UtcOffset::UTC).date(),
+            // Round up end to nearest date
+            end: if utc_end.time() == Time::MIDNIGHT {
+                utc_end.date()
+            } else {
+                utc_end.date().next_day().unwrap()
+            },
         }
     }
 }
@@ -140,7 +185,7 @@ impl DateTimeRange {
 mod tests {
     use super::*;
 
-    use time::macros::date;
+    use time::macros::{date, datetime};
 
     #[test]
     fn date_range_from_lt_day_duration() {
@@ -152,5 +197,48 @@ mod tests {
                 end: date!(2024 - 02 - 16)
             }
         )
+    }
+
+    #[test]
+    fn single_date_conversion() {
+        let date = date!(2025 - 03 - 27);
+        assert_eq!(
+            DateRange::from(date),
+            DateRange::from((date!(2025 - 03 - 27), date!(2025 - 03 - 28)))
+        );
+        assert_eq!(
+            DateTimeRange::from(date),
+            DateTimeRange::from((
+                datetime!(2025 - 03 - 27 00:00 UTC),
+                datetime!(2025 - 03 - 28 00:00 UTC)
+            ))
+        );
+    }
+
+    #[test]
+    fn range_equivalency() {
+        let date_range = DateRange::from((date!(2025 - 03 - 27), date!(2025 - 04 - 10)));
+        assert_eq!(
+            date_range,
+            DateRange::from(DateTimeRange::from(date_range.clone()))
+        );
+    }
+
+    #[test]
+    fn dt_offset_to_date_range() {
+        assert_eq!(
+            DateRange::from(DateTimeRange::from((
+                datetime!(2025-03-27 21:00 -4),
+                datetime!(2025-03-28 20:00 -4)
+            ))),
+            DateRange::from((date!(2025 - 03 - 28), date!(2025 - 03 - 29)))
+        );
+        assert_eq!(
+            DateRange::from(DateTimeRange::from((
+                datetime!(2025-03-27 21:00 -4),
+                datetime!(2025-03-28 20:30 -4)
+            ))),
+            DateRange::from((date!(2025 - 03 - 28), date!(2025 - 03 - 30)))
+        );
     }
 }

--- a/src/historical/batch.rs
+++ b/src/historical/batch.rs
@@ -34,6 +34,10 @@ pub struct BatchClient<'a> {
 impl BatchClient<'_> {
     /// Submits a new batch job and returns a description and identifiers for the job.
     ///
+    /// <div class="warning">
+    /// Calling this method will incur a cost.
+    /// </div>
+    ///
     /// # Errors
     /// This function returns an error when it fails to communicate with the Databento API
     /// or the API indicates there's an issue with the request.

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -31,6 +31,10 @@ impl TimeseriesClient<'_> {
     /// This method returns a stream decoder. For larger requests, consider using
     /// [`BatchClient::submit_job()`](super::batch::BatchClient::submit_job()).
     ///
+    /// <div class="warning">
+    /// Calling this method will incur a cost.
+    /// </div>
+    ///
     /// # Errors
     /// This function returns an error when it fails to communicate with the Databento API
     /// or the API indicates there's an issue with the request.
@@ -58,6 +62,10 @@ impl TimeseriesClient<'_> {
     ///
     /// This method returns a stream decoder. For larger requests, consider using
     /// [`BatchClient::submit_job()`](super::batch::BatchClient::submit_job()).
+    ///
+    /// <div class="warning">
+    /// Calling this method will incur a cost.
+    /// </div>
     ///
     /// # Errors
     /// This function returns an error when it fails to communicate with the Databento API


### PR DESCRIPTION
##### Enhancements
- Added an implementation `From<Date>` for `DateRange` and `DateTimeRange` to make it
  simpler to request a single full day's worth of data
- Added conversions between `DateRange` and `DateTimeRange`
- Added conversions from `timeseries::GetRangeParams`, `timeseries::GetRangeToFileParams`,
  and `dbn::Metadata` to `symbology::ResolveParams`
- Upgraded DBN version to 0.30.0:
  - Added support for mapping symbols from instrument definitions to `PitSymbolMap`
    with a new `on_instrument_def()` method
  - Added instrument definition compatibility trait `InstrumentDefRec` for generalizing
    across different versions of the instrument definition record
  - Added `Ord` and `PartialOrd` implementations for all enums and `FlagSet` to allow
    for use in ordered containers like `BTreeMap`
  - Added `decode_records()` method to `AsyncDbnDecoder` and `AsyncDbnRecordDecoder`
    which is similar to the sync decoder methods of the same name
  - Removed deprecated `dataset` module. The top-level `Dataset` enum and its `const` `as_str()`
    method provide the same functionality for all datasets
  - Removed deprecated `SymbolIndex::get_for_rec_ref()` method