### PR TITLE
VER: Release 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.24.0 - 2025-04-22
+
+### Enhancements
+- Upgraded DBN version to 0.33.0:
+  - Added `SystemCode` and `ErrorCode` enums to indicate types of system and error
+    messages
+  - Added `code()` methods to `SystemMsg` and `ErrorMsg` to retrieve the enum value if
+    one exists and equivalent properties in Python
+  - Converting a `v1::SystemMsg` to a `v2::SystemMsg` now sets to `code` to the
+    heartbeat value
+  - Added `ASSET_CSTR_LEN` constants for the size of `asset` field in `InstrumentDefMsg`
+    in different DBN versions
+  - Added `encode_record_with_sym()`  method to `AsyncJsonEncoder` which encodes a
+    record along with its text symbol to match the sync encoder
+
+### Breaking changes
+- Breaking changes from DBN:
+  - Added `code` parameter to `SystemCode::new()` and `ErrorMsg::new()`
+  - Updated the `rtype_dispatch` and `schema_dispatch` macro invocations to look more
+    like function invocation
+  - Increased the size of `asset` field in `v3::InstrumentDefMsg` from 7 to 11. The
+    `InstrumentDefMsgV3` message size remains 520 bytes.
+
 ## 0.23.0 - 2025-04-15
 
 ### Enhancements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -23,7 +23,7 @@ historical = ["dep:futures", "dep:reqwest", "dep:serde", "dep:tokio-util", "dep:
 live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
-dbn = { version = "0.32.0", features = ["async", "serde"] }
+dbn = { version = "0.33.0", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication
@@ -42,9 +42,9 @@ tracing = "0.1"
 typed-builder = "0.21"
 
 [dev-dependencies]
-anyhow = "1.0.97"
-async-compression = { version = "0.4.22", features = ["tokio", "zstd"] }
-clap = { version = "4.5.35", features = ["derive"] }
+anyhow = "1.0.98"
+async-compression = { version = "0.4.23", features = ["tokio", "zstd"] }
+clap = { version = "4.5.37", features = ["derive"] }
 tempfile = "3.19.1"
 tokio = { version = "1.44", features = ["full"] }
 tracing-subscriber = "0.3.19"

--- a/src/historical/batch.rs
+++ b/src/historical/batch.rs
@@ -244,7 +244,8 @@ pub struct SubmitJobParams {
     pub symbols: Symbols,
     /// The data record schema.
     pub schema: Schema,
-    /// The request time range.
+    /// The date time request range.
+    /// Filters on `ts_recv` if it exists in the schema, otherwise `ts_event`.
     #[builder(setter(into))]
     pub date_time_range: DateTimeRange,
     /// The data encoding. Defaults to [`Dbn`](Encoding::Dbn).

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -153,7 +153,8 @@ pub struct GetRangeParams {
     pub symbols: Symbols,
     /// The data record schema.
     pub schema: Schema,
-    /// The request time range.
+    /// The date time request range.
+    /// Filters on `ts_recv` if it exists in the schema, otherwise `ts_event`.
     #[builder(setter(into))]
     pub date_time_range: DateTimeRange,
     /// The symbology type of the input `symbols`. Defaults to
@@ -184,7 +185,8 @@ pub struct GetRangeToFileParams {
     pub symbols: Symbols,
     /// The data record schema.
     pub schema: Schema,
-    /// The request time range.
+    /// The date time request range.
+    /// Filters on `ts_recv` if it exists in the schema, otherwise `ts_event`.
     #[builder(setter(into))]
     pub date_time_range: DateTimeRange,
     /// The symbology type of the input `symbols`. Defaults to


### PR DESCRIPTION
### Enhancements
- Upgraded DBN version to 0.33.0:
  - Added `SystemCode` and `ErrorCode` enums to indicate types of system and error
    messages
  - Added `code()` methods to `SystemMsg` and `ErrorMsg` to retrieve the enum value if
    one exists and equivalent properties in Python
  - Converting a `v1::SystemMsg` to a `v2::SystemMsg` now sets to `code` to the
    heartbeat value
  - Added `ASSET_CSTR_LEN` constants for the size of `asset` field in `InstrumentDefMsg`
    in different DBN versions
  - Added `encode_record_with_sym()`  method to `AsyncJsonEncoder` which encodes a
    record along with its text symbol to match the sync encoder

### Breaking changes
- Breaking changes from DBN:
  - Added `code` parameter to `SystemCode::new()` and `ErrorMsg::new()`
  - Updated the `rtype_dispatch` and `schema_dispatch` macro invocations to look more
    like function invocation
  - Increased the size of `asset` field in `v3::InstrumentDefMsg` from 7 to 11. The
    `InstrumentDefMsgV3` message size remains 520 bytes.
