### PR TITLE
VER: Release 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.25.1 - TBD
+
+### Enhancements
+- Added `From<DatasetRange>` conversion for `DateTimeRange`
+
 ## 0.25.0 - TBD
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,39 @@
 # Changelog
 
-## 0.26.0 - TBD
 
-### Enhancements
+## 0.26.0 - 2025-05-28
 
+This version marks the release of DBN version 3 (DBNv3), which is the new default.
+API methods and decoders support decoding all versions of DBN, but now default to
+upgrading data to version 3.
+
+### Enhancements - Added `From<DatasetRange>` conversion for `DateTimeRange`
 - Added `is_last` field to live subscription requests which will be used to improve the
   handling of split subscription requests
-- Added `From<DatasetRange>` conversion for `DateTimeRange`
+- Upgraded DBN version to 0.35.0:
+  - Version 1 and 2 structs can be converted to version 3 structs with the `From` trait
+  - Implemented conversion from `RecordRef` to `IoSlice` for use with
+    `Write::write_vectored`
+
+### Breaking changes
+- Breaking changes from DBN:
+  - Definition schema:
+    - Updated `InstrumentDefMsg` with new `leg_` fields to support multi-leg strategy
+      definitions.
+    - Expanded `asset` to 11 bytes and `ASSET_CSTR_LEN` to match
+    - Expanded `raw_instrument_id` to 64 bits to support more venues. Like other 64-bit
+      integer fields, its value will now be quoted in JSON
+    - Removed `trading_reference_date`, `trading_reference_price`, and
+      `settl_price_type` fields which will be normalized in the statistics schema
+    - Removed `md_security_trading_status` better served by the status schema
+  - Statistics schema:
+    - Updated `StatMsg` has an expanded 64-bit `quantity` field. Like other 64-bit
+      integer fields, its value will now be quoted in JSON
+    - The previous `StatMsg` has been moved to `v2::StatMsg` or `StatMsgV2`
+  - Changed the default `VersionUpgradePolicy` to `UpgradeToV3`
+  - Updated the minimum supported `tokio` version to 1.38, which was released one year ago
+
+## 0.25.0 - 2025-05-13
 
 ### Enhancements
 - Increased live subscription symbol chunking size

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## 0.25.1 - TBD
+## 0.26.0 - TBD
 
 ### Enhancements
-- Added `From<DatasetRange>` conversion for `DateTimeRange`
 
-## 0.25.0 - TBD
+- Added `is_last` field to live subscription requests which will be used to improve the
+  handling of split subscription requests
+- Added `From<DatasetRange>` conversion for `DateTimeRange`
 
 ### Enhancements
 - Increased live subscription symbol chunking size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ historical = ["dep:futures", "dep:reqwest", "dep:serde", "dep:tokio-util", "dep:
 live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
-dbn = { version = "0.34.0", features = ["async", "serde"] }
+dbn = { version = "0.35.0", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication
@@ -44,8 +44,8 @@ typed-builder = "0.21"
 [dev-dependencies]
 anyhow = "1.0.98"
 async-compression = { version = "0.4.23", features = ["tokio", "zstd"] }
-clap = { version = "4.5.37", features = ["derive"] }
-tempfile = "3.19.1"
-tokio = { version = "1.44", features = ["full"] }
+clap = { version = "4.5.39", features = ["derive"] }
+tempfile = "3.20.0"
+tokio = { version = "1.45", features = ["full"] }
 tracing-subscriber = "0.3.19"
 wiremock = "0.6"

--- a/src/historical/metadata.rs
+++ b/src/historical/metadata.rs
@@ -159,7 +159,7 @@ impl MetadataClient<'_> {
     }
 
     /// Gets the cost in US dollars for a historical streaming or batch download
-    /// request.
+    /// request. This cost respects any discounts provided by flat rate plans.
     ///
     /// # Errors
     /// This function returns an error when it fails to communicate with the Databento API

--- a/src/historical/metadata.rs
+++ b/src/historical/metadata.rs
@@ -286,6 +286,12 @@ pub struct DatasetRange {
     pub end: time::OffsetDateTime,
 }
 
+impl From<DatasetRange> for DateTimeRange {
+    fn from(DatasetRange { start, end }: DatasetRange) -> Self {
+        Self { start, end }
+    }
+}
+
 impl<'de> Deserialize<'de> for DatasetRange {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -132,7 +132,7 @@ impl TimeseriesClient<'_> {
             .await?
             .error_for_status()?
             .bytes_stream()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+            .map_err(std::io::Error::other);
         Ok(tokio_util::io::StreamReader::new(stream))
     }
 

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -54,7 +54,7 @@ impl TimeseriesClient<'_> {
             )
             .await?;
         let mut decoder: AsyncDbnDecoder<_> = AsyncDbnDecoder::with_zstd_buffer(reader).await?;
-        decoder.set_upgrade_policy(params.upgrade_policy);
+        decoder.set_upgrade_policy(params.upgrade_policy)?;
         Ok(decoder)
     }
 
@@ -87,7 +87,7 @@ impl TimeseriesClient<'_> {
             )
             .await?;
         let mut http_decoder = AsyncDbnDecoder::with_zstd_buffer(reader).await?;
-        http_decoder.set_upgrade_policy(params.upgrade_policy);
+        http_decoder.set_upgrade_policy(params.upgrade_policy)?;
         let file = BufWriter::new(File::create(&params.path).await?);
         let mut encoder = AsyncDbnEncoder::with_zstd(file, http_decoder.metadata()).await?;
         while let Some(rec_ref) = http_decoder.decode_record_ref().await? {

--- a/src/live/client.rs
+++ b/src/live/client.rs
@@ -37,6 +37,7 @@ pub struct Client {
     span: Span,
 }
 
+#[allow(clippy::large_enum_variant)]
 enum Decoder {
     Metadata(AsyncMetadataDecoder<BufReader<ReadHalf<TcpStream>>>),
     Record(AsyncRecordDecoder<BufReader<ReadHalf<TcpStream>>>),


### PR DESCRIPTION
This version marks the release of DBN version 3 (DBNv3), which is the new default.
API methods and decoders support decoding all versions of DBN, but now default to
upgrading data to version 3.

### Enhancements - Added `From<DatasetRange>` conversion for `DateTimeRange`
- Added `is_last` field to live subscription requests which will be used to improve the
  handling of split subscription requests
- Upgraded DBN version to 0.35.0:
  - Version 1 and 2 structs can be converted to version 3 structs with the `From` trait
  - Implemented conversion from `RecordRef` to `IoSlice` for use with
    `Write::write_vectored`

### Breaking changes
- Breaking changes from DBN:
  - Definition schema:
    - Updated `InstrumentDefMsg` with new `leg_` fields to support multi-leg strategy
      definitions.
    - Expanded `asset` to 11 bytes and `ASSET_CSTR_LEN` to match
    - Expanded `raw_instrument_id` to 64 bits to support more venues. Like other 64-bit
      integer fields, its value will now be quoted in JSON
    - Removed `trading_reference_date`, `trading_reference_price`, and
      `settl_price_type` fields which will be normalized in the statistics schema
    - Removed `md_security_trading_status` better served by the status schema
  - Statistics schema:
    - Updated `StatMsg` has an expanded 64-bit `quantity` field. Like other 64-bit
      integer fields, its value will now be quoted in JSON
    - The previous `StatMsg` has been moved to `v2::StatMsg` or `StatMsgV2`
  - Changed the default `VersionUpgradePolicy` to `UpgradeToV3`
  - Updated the minimum supported `tokio` version to 1.38, which was released one year ago

