### PR TITLE
VER: Release 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.26.1 - 2025-05-30
+
+### Bug fixes
+- Fixed handling of `VersionUpgradePolicy` in live client
+- Fixed default upgrade policies to `UpgradeToV3` to match announcement for
+  version 0.26.0
 
 ## 0.26.0 - 2025-05-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -169,7 +169,7 @@ pub struct GetRangeParams {
     #[builder(default)]
     pub limit: Option<NonZeroU64>,
     /// How to decode DBN from prior versions. Defaults to upgrade.
-    #[builder(default = VersionUpgradePolicy::UpgradeToV2)]
+    #[builder(default)]
     pub upgrade_policy: VersionUpgradePolicy,
 }
 
@@ -201,7 +201,7 @@ pub struct GetRangeToFileParams {
     #[builder(default)]
     pub limit: Option<NonZeroU64>,
     /// How to decode DBN from prior versions. Defaults to upgrade.
-    #[builder(default = VersionUpgradePolicy::UpgradeToV2)]
+    #[builder(default)]
     pub upgrade_policy: VersionUpgradePolicy,
     /// The file path to persist the stream data to.
     #[builder(default, setter(transform = |p: impl Into<PathBuf>| p.into()))]

--- a/src/live.rs
+++ b/src/live.rs
@@ -67,7 +67,7 @@ impl Default for ClientBuilder<Unset, Unset> {
             key: Unset,
             dataset: Unset,
             send_ts_out: false,
-            upgrade_policy: VersionUpgradePolicy::UpgradeToV2,
+            upgrade_policy: VersionUpgradePolicy::default(),
             heartbeat_interval: None,
         }
     }


### PR DESCRIPTION
- Fixed handling of `VersionUpgradePolicy` in live client
- Fixed default upgrade policies to `UpgradeToV3` to match announcement for
  version 0.26.0