### PR TITLE
VER: Release 0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.26.2 - TBD
+## 0.26.2 - 2025-06-03
 
 ### Enhancements
 - Improved performance of live client by removing redundant state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Changelog
 
-## 0.26.1 - 2025-05-30
+## 0.26.2 - TBD
 
 ### Enhancements
 - Improved performance of live client by removing redundant state
+- Upgraded DBN version to 0.35.1
+
+### Bug fixes
+- Fixed handling of `VersionUpgradePolicy` in `timeseries().get_range()` and
+  `get_range_to_file()`
+- Bug fixes from DBN:
+  - Fixed behavior where encoding metadata could lower the `version`
+  - Changed `DbnFsm::data()` to exclude all processed data
+  - Fixed `Metadata::upgrade()` behavior with `UpgradeToV2`
+
+## 0.26.1 - 2025-05-30
 
 ### Bug fixes
 - Fixed handling of `VersionUpgradePolicy` in live client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.26.1 - 2025-05-30
 
+### Enhancements
+- Improved performance of live client by removing redundant state
+
 ### Bug fixes
 - Fixed handling of `VersionUpgradePolicy` in live client
 - Fixed default upgrade policies to `UpgradeToV3` to match announcement for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,21 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["historical", "live"]
-historical = ["dep:futures", "dep:reqwest", "dep:serde", "dep:tokio-util", "dep:serde_json", "tokio/fs"]
+historical = [
+  "dep:async-compression",
+  "dep:futures",
+  "dep:reqwest",
+  "dep:serde",
+  "dep:tokio-util",
+  "dep:serde_json",
+  "tokio/fs"
+]
 live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
 dbn = { version = "0.35.1", features = ["async", "serde"] }
+
+async-compression = { version = "0.4", features = ["tokio", "zstd"], optional = true }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication
@@ -43,8 +53,9 @@ typed-builder = "0.21"
 
 [dev-dependencies]
 anyhow = "1.0.98"
-async-compression = { version = "0.4.23", features = ["tokio", "zstd"] }
+async-compression = { version = "0.4", features = ["tokio", "zstd"] }
 clap = { version = "4.5.37", features = ["derive"] }
+rstest = "0.25.0"
 tempfile = "3.19.1"
 tokio = { version = "1.44", features = ["full"] }
 tracing-subscriber = "0.3.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.26.1"
+version = "0.26.2"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ historical = ["dep:futures", "dep:reqwest", "dep:serde", "dep:tokio-util", "dep:
 live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
-dbn = { version = "0.35.0", features = ["async", "serde"] }
+dbn = { version = "0.35.1", features = ["async", "serde"] }
 # Async stream trait
 futures = { version = "0.3", optional = true }
 # Used for Live authentication


### PR DESCRIPTION
##### Enhancements
- Improved performance of live client by removing redundant state
- Upgraded DBN version to 0.35.1

##### Bug fixes
- Fixed handling of `VersionUpgradePolicy` in `timeseries().get_range()` and
  `get_range_to_file()`
- Bug fixes from DBN:
  - Fixed behavior where encoding metadata could lower the `version`
  - Changed `DbnFsm::data()` to exclude all processed data
  - Fixed `Metadata::upgrade()` behavior with `UpgradeToV2`
