### PR TITLE
VER: Release 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,27 @@
 # Changelog
 
-## 0.27.0 - TBD
+## 0.27.0 - 2025-06-10
 
 ### Enhancements
 - Made the buffer size used by the live client when reading from the TCP socket
   configurable through the `LiveBuilder::buffer_size()` method
 - Added support for using `rustls` without pulling in OpenSSL. `reqwest` with OpenSSL is
   still the default
+- Upgraded DBN version to 0.36.0:
+  - Added support for width, fill, and padding when formatting `pretty::Ts`
+  - Added support for sign, precision, width, fill, and padding when formatting
+    `pretty::Px`
+  - Optimized pretty formatting of prices and timestamps
 
 ### Breaking changes
 - Changed type of `split_duration` to `Option<SplitDuration>` to support setting no
   split duration
+- Breaking changes from DBN:
+  - Moved core async decoding and encoding functionality to new traits to
+    match the sync interface and present a standardized interface
+    - Decoding: `AsyncDecodeRecordRef` and `AsyncDecodeRecord`
+    - Encoding: `AsyncEncodeRecord`, `AsyncEncodeRecordRef`, and
+      `AsyncEncodeRecordTextExt`
 
 ### Deprecations
 - Deprecated `LiveClient::connect` and `LiveClient::connect_with_addr` methods in favor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.26.3 - TBD
+
+### Bug fixes
+- Fixed bug with deserializing `null` `split_duration` in historical
+  `batch().list_jobs()`
+
+### Bug fixes
+- Fixed bug with deserializing `null` `split_duration` in historical
+  `batch().list_jobs()`
+
 ## 0.26.2 - 2025-06-03
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,19 @@
 ## 0.27.0 - TBD
 
 ### Enhancements
+- Made the buffer size used by the live client when reading from the TCP socket
+  configurable through the `LiveBuilder::buffer_size()` method
 - Added support for using `rustls` without pulling in OpenSSL. `reqwest` with OpenSSL is
   still the default
 
 ### Breaking changes
 - Changed type of `split_duration` to `Option<SplitDuration>` to support setting no
   split duration
+
+### Deprecations
+- Deprecated `LiveClient::connect` and `LiveClient::connect_with_addr` methods in favor
+  of using the builder so additional optional parameters can be added without a breaking
+  change
 
 ### Bug fixes
 - Fixed bug with deserializing `null` `split_duration` in historical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## 0.26.3 - TBD
+## 0.27.0 - TBD
 
-### Bug fixes
-- Fixed bug with deserializing `null` `split_duration` in historical
-  `batch().list_jobs()`
+### Enhancements
+- Added support for using `rustls` without pulling in OpenSSL. `reqwest` with OpenSSL is
+  still the default
+
+### Breaking changes
+- Changed type of `split_duration` to `Option<SplitDuration>` to support setting no
+  split duration
 
 ### Bug fixes
 - Fixed bug with deserializing `null` `split_duration` in historical

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["historical", "live"]
+default = ["historical", "live", "reqwest/default-tls"]
 historical = [
   "dep:async-compression",
   "dep:futures",
@@ -38,7 +38,7 @@ async-compression = { version = "0.4", features = ["tokio", "zstd"], optional = 
 futures = { version = "0.3", optional = true }
 # Used for Live authentication
 hex = { version = "0.4", optional = true }
-reqwest = { version = "0.12", optional = true, features = ["json", "stream"] }
+reqwest = { version = "0.12", optional = true, features = ["json", "stream"], default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 # Used for Live authentication

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.26.2"
+version = "0.27.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -31,7 +31,7 @@ historical = [
 live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
-dbn = { version = "0.35.1", features = ["async", "serde"] }
+dbn = { version = "0.36.0", features = ["async", "serde"] }
 
 async-compression = { version = "0.4", features = ["tokio", "zstd"], optional = true }
 # Async stream trait

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 The official Rust client library for [Databento](https://databento.com).
 The clients support fast and safe streaming of both real-time and historical market data
 through similar interfaces.
+The library is built on top of the tokio asynchronous runtime and
+[Databento's efficient binary encoding](https://databento.com/docs/standards-and-conventions/databento-binary-encoding).
+
+You can find getting started tutorials, full API method documentation, examples with output on the
+[Databento docs site](https://databento.com/docs/?historical=rust&live=rust).
 
 ## Installation
 
@@ -17,14 +22,70 @@ To add the crate to an existing project, run the following command:
 cargo add databento
 ```
 
+### Feature flags
+
+- `historical`: enables the historical client for data older than 24 hours
+- `live`: enables the live client for real-time and intraday historical data
+
+By default both features are enabled and the historical client uses OpenSSL for TLS.
+To use `rustls`, disable default features for both the databento crate and [reqwest](https://github.com/seanmonstar/reqwest).
+```toml
+databento = { features = ["historical"], default-features = false }
+reqwest = { features = ["rustls-tls"], default-features = false }
+```
+
 ## Usage
+
+### Historical
+
+Here is a simple program that fetches 10 minutes worth of historical trades for E-mini S&P 500 futures from CME Globex:
+```rust no_run
+use std::error::Error;
+
+use databento::{
+    dbn::{Dataset, SType, Schema, TradeMsg},
+    historical::timeseries::GetRangeParams,
+    HistoricalClient,
+};
+use time::macros::{date, datetime};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut client = HistoricalClient::builder().key_from_env()?.build()?;
+    let mut decoder = client
+        .timeseries()
+        .get_range(
+            &GetRangeParams::builder()
+                .dataset(Dataset::GlbxMdp3)
+                .date_time_range((
+                    datetime!(2022-06-10 14:30 UTC),
+                    datetime!(2022-06-10 14:40 UTC),
+                ))
+                .symbols("ES.FUT")
+                .stype_in(SType::Parent)
+                .schema(Schema::Trades)
+                .build(),
+        )
+        .await?;
+    let symbol_map = decoder
+        .metadata()
+        .symbol_map_for_date(date!(2022 - 06 - 10))?;
+    while let Some(trade) = decoder.decode_record::<TradeMsg>().await? {
+        let symbol = &symbol_map[trade];
+        println!("Received trade for {symbol}: {trade:?}");
+    }
+    Ok(())
+}
+```
+
+To run this program, set the `DATABENTO_API_KEY` environment variable with an API key and run `cargo bin --example historical`.
 
 ### Live
 
 Real-time and intraday replay is provided through the Live clients.
-Here is a simple program that fetches the next ES mini futures trade:
+Here is a simple program that fetches the next E-mini S&P 500 futures trade:
 
-```rust
+```rust no_run
 use std::error::Error;
 
 use databento::{
@@ -65,54 +126,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 ```
-To run this program, set the `DATABENTO_API_KEY` environment variable with an API key and run `cargo run --example historical`
 
-### Historical
-
-Here is a simple program that fetches 10 minutes worth of historical trades for the entire CME Globex market:
-```rust
-use std::error::Error;
-
-use databento::{
-    dbn::{Schema, TradeMsg},
-    historical::timeseries::GetRangeParams,
-    HistoricalClient, Symbols,
-};
-use time::macros::{date, datetime};
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    let mut client = HistoricalClient::builder().key_from_env()?.build()?;
-    let mut decoder = client
-        .timeseries()
-        .get_range(
-            &GetRangeParams::builder()
-                .dataset("GLBX.MDP3")
-                .date_time_range((
-                    datetime!(2022-06-10 14:30 UTC),
-                    datetime!(2022-06-10 14:40 UTC),
-                ))
-                .symbols(Symbols::All)
-                .schema(Schema::Trades)
-                .build(),
-        )
-        .await?;
-    let symbol_map = decoder
-        .metadata()
-        .symbol_map_for_date(date!(2022 - 06 - 10))?;
-    while let Some(trade) = decoder.decode_record::<TradeMsg>().await? {
-        let symbol = &symbol_map[trade];
-        println!("Received trade for {symbol}: {trade:?}");
-    }
-    Ok(())
-}
-```
-
-To run this program, set the `DATABENTO_API_KEY` environment variable with an API key and run `cargo bin --example live`.
-
-## Documentation
-
-You can find more detailed examples and the full API documentation on the [Databento docs site](https://databento.com/docs/quickstart?historical=rust&live=rust).
+To run this program, set the `DATABENTO_API_KEY` environment variable with an API key and run `cargo run --example live`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Here is a simple program that fetches 10 minutes worth of historical trades for 
 use std::error::Error;
 
 use databento::{
-    dbn::{Dataset, SType, Schema, TradeMsg},
+    dbn::{decode::DbnMetadata, Dataset, SType, Schema, TradeMsg},
     historical::timeseries::GetRangeParams,
     HistoricalClient,
 };

--- a/examples/historical.rs
+++ b/examples/historical.rs
@@ -2,7 +2,7 @@
 use std::error::Error;
 
 use databento::{
-    dbn::{Dataset, SType, Schema, TradeMsg},
+    dbn::{decode::DbnMetadata, Dataset, SType, Schema, TradeMsg},
     historical::timeseries::GetRangeParams,
     HistoricalClient,
 };

--- a/examples/historical.rs
+++ b/examples/historical.rs
@@ -2,9 +2,9 @@
 use std::error::Error;
 
 use databento::{
-    dbn::{Schema, TradeMsg},
+    dbn::{Dataset, SType, Schema, TradeMsg},
     historical::timeseries::GetRangeParams,
-    HistoricalClient, Symbols,
+    HistoricalClient,
 };
 use time::macros::{date, datetime};
 
@@ -15,12 +15,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .timeseries()
         .get_range(
             &GetRangeParams::builder()
-                .dataset("GLBX.MDP3")
+                .dataset(Dataset::GlbxMdp3)
                 .date_time_range((
                     datetime!(2022-06-10 14:30 UTC),
                     datetime!(2022-06-10 14:40 UTC),
                 ))
-                .symbols(Symbols::All)
+                .symbols("ES.FUT")
+                .stype_in(SType::Parent)
                 .schema(Schema::Trades)
                 .build(),
         )

--- a/examples/split_symbols.rs
+++ b/examples/split_symbols.rs
@@ -6,8 +6,9 @@ use anyhow::Context;
 use async_compression::tokio::write::ZstdEncoder;
 use databento::{
     dbn::{
-        decode::AsyncDbnDecoder, encode::AsyncDbnEncoder, InstrumentDefMsg, Metadata, Schema,
-        SymbolIndex,
+        decode::{AsyncDbnDecoder, DbnMetadata},
+        encode::{AsyncDbnEncoder, AsyncEncodeRecord, AsyncEncodeRecordRef},
+        InstrumentDefMsg, Metadata, Schema, SymbolIndex,
     },
     historical::timeseries::GetRangeParams,
     HistoricalClient,
@@ -55,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
             encoders.insert(parent.clone(), encoder);
         };
     }
-    for (parent, encoder) in encoders {
+    for (parent, mut encoder) in encoders {
         if let Err(e) = encoder.shutdown().await {
             eprintln!("Failed to shutdown encoder for {parent}: {e:?}");
         }

--- a/src/historical/symbology.rs
+++ b/src/historical/symbology.rs
@@ -82,12 +82,15 @@ impl TryFrom<Metadata> for ResolveParams {
     type Error = crate::Error;
 
     fn try_from(metadata: Metadata) -> Result<Self, Self::Error> {
-        let stype_in = metadata
-            .stype_in
-            .ok_or_else(|| crate::Error::bad_arg("metadata", "stype_in must be Some value"))?;
-        let end = metadata
-            .end()
-            .ok_or_else(|| crate::Error::bad_arg("metadata", "end must be Some value"))?;
+        let stype_in = metadata.stype_in.ok_or_else(|| {
+            crate::Error::bad_arg(
+                "metadata",
+                "stype_in must be Some value for resolution request",
+            )
+        })?;
+        let end = metadata.end().ok_or_else(|| {
+            crate::Error::bad_arg("metadata", "end must be Some value for resolution request")
+        })?;
         let dt_range = DateTimeRange::from((metadata.start(), end));
         Ok(Self {
             dataset: metadata.dataset,

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -2,7 +2,11 @@
 
 use std::{num::NonZeroU64, path::PathBuf};
 
-use dbn::{encode::AsyncDbnEncoder, Compression, Encoding, SType, Schema, VersionUpgradePolicy};
+use dbn::{
+    decode::DbnMetadata,
+    encode::{AsyncDbnEncoder, AsyncEncodeRecordRef},
+    Compression, Encoding, SType, Schema, VersionUpgradePolicy,
+};
 use futures::{Stream, TryStreamExt};
 use reqwest::{header::ACCEPT, RequestBuilder};
 use tokio::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,5 @@
-//! The official [Databento](https://databento.com) client library.
-//! It provides clients for fast, safe streaming of both real-time and historical market data through
-//! similar interfaces.
-//! The library is built on top of the tokio asynchronous runtime and
-//! [Databento's efficient binary encoding](https://databento.com/docs/standards-and-conventions/databento-binary-encoding).
-//!
-//! You can find getting started tutorials, full API method documentation, examples
-//! with output on the [Databento docs site](https://databento.com/docs/?historical=rust&live=rust).
-//!
-//! # Feature flags
-//! By default both features are enabled.
-//! - `historical`: enables the [historical client](HistoricalClient) for data older than 24 hours
-//! - `live`: enables the [live client](LiveClient) for real-time and intraday
-//!   historical data
-
+// Use README as crate-level documentation
+#![doc = include_str!("../README.md")]
 // Experimental feature to allow docs.rs to display features
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(missing_docs)]


### PR DESCRIPTION
### Enhancements
- Made the buffer size used by the live client when reading from the TCP socket
  configurable through the `LiveBuilder::buffer_size()` method
- Added support for using `rustls` without pulling in OpenSSL. `reqwest` with OpenSSL is
  still the default
- Upgraded DBN version to 0.36.0:
  - Added support for width, fill, and padding when formatting `pretty::Ts`
  - Added support for sign, precision, width, fill, and padding when formatting
    `pretty::Px`
  - Optimized pretty formatting of prices and timestamps

### Breaking changes
- Changed type of `split_duration` to `Option<SplitDuration>` to support setting no
  split duration
- Breaking changes from DBN:
  - Moved core async decoding and encoding functionality to new traits to
    match the sync interface and present a standardized interface
    - Decoding: `AsyncDecodeRecordRef` and `AsyncDecodeRecord`
    - Encoding: `AsyncEncodeRecord`, `AsyncEncodeRecordRef`, and
      `AsyncEncodeRecordTextExt`

### Deprecations
- Deprecated `LiveClient::connect` and `LiveClient::connect_with_addr` methods in favor
  of using the builder so additional optional parameters can be added without a breaking
  change

### Bug fixes
- Fixed bug with deserializing `null` `split_duration` in historical
  `batch().list_jobs()`