### PR TITLE
VER: Release 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.28.0 - TBD
+
+### Enhancements
+- Added operating system info to the user agent to aid troubleshooting
+- Standardized `client` info sent by live clients to match historical
+- Added methods to the client builders to extend the user agents with a custom string
+
+### Deprecations
+- Deprecated `Historical::with_url()`: use the builder to override the base URL
+- Deprecated the `upgrade_policy` parameters for `timseries().get_range()` and
+  `timeseries().get_range_to_file()`: use the `Historical` client parameter
+  instead
+
 ## 0.27.1 - 2025-06-25
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.28.0 - TBD
+## 0.28.0 - 2025-07-01
 
 ### Enhancements
 - Added operating system info to the user agent to aid troubleshooting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento"
 authors = ["Databento <support@databento.com>"]
-version = "0.27.1"
+version = "0.28.0"
 edition = "2021"
 repository = "https://github.com/databento/databento-rs"
 description = "Official Databento client library"
@@ -45,7 +45,7 @@ serde_json = { version = "1.0", optional = true }
 sha2 = { version = "0.10", optional = true }
 thiserror = "2.0"
 time = { version = ">=0.3.35", features = ["macros", "parsing", "serde"] }
-tokio = { version = ">=1.28", features = ["io-util", "macros"] }
+tokio = { version = ">=1.38", features = ["io-util", "macros"] }
 # Stream utils
 tokio-util = { version = "0.7", features = ["io"], optional = true }
 tracing = "0.1"
@@ -54,9 +54,9 @@ typed-builder = "0.21"
 [dev-dependencies]
 anyhow = "1.0.98"
 async-compression = { version = "0.4", features = ["tokio", "zstd"] }
-clap = { version = "4.5.37", features = ["derive"] }
+clap = { version = "4.5.40", features = ["derive"] }
 rstest = "0.25.0"
-tempfile = "3.19.1"
-tokio = { version = "1.44", features = ["full"] }
+tempfile = "3.20.0"
+tokio = { version = "1.45", features = ["full"] }
 tracing-subscriber = "0.3.19"
 wiremock = "0.6"

--- a/src/historical/batch.rs
+++ b/src/historical/batch.rs
@@ -567,13 +567,18 @@ mod tests {
     };
 
     use super::*;
-    use crate::{
-        body_contains,
-        historical::{HistoricalGateway, API_VERSION},
-        HistoricalClient,
-    };
+    use crate::{body_contains, historical::API_VERSION, HistoricalClient};
 
-    const API_KEY: &str = "test-batch";
+    const API_KEY: &str = "test-API________________________";
+
+    fn client(mock_server: &MockServer) -> HistoricalClient {
+        HistoricalClient::builder()
+            .base_url(mock_server.uri().parse().unwrap())
+            .key(API_KEY)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn test_submit_job() -> crate::Result<()> {
@@ -632,11 +637,7 @@ mod tests {
             )
             .mount(&mock_server)
             .await;
-        let mut target = HistoricalClient::with_url(
-            mock_server.uri(),
-            API_KEY.to_owned(),
-            HistoricalGateway::Bo1,
-        )?;
+        let mut target = client(&mock_server);
         let job_desc = target
             .batch()
             .submit_job(
@@ -731,11 +732,7 @@ mod tests {
             )
             .mount(&mock_server)
             .await;
-        let mut target = HistoricalClient::with_url(
-            mock_server.uri(),
-            API_KEY.to_owned(),
-            HistoricalGateway::Bo1,
-        )?;
+        let mut target = client(&mock_server);
         let job_descs = target.batch().list_jobs(&ListJobsParams::default()).await?;
         assert_eq!(job_descs.len(), 2);
         let mut job_desc = &job_descs[0];

--- a/src/historical/metadata.rs
+++ b/src/historical/metadata.rs
@@ -460,12 +460,18 @@ mod tests {
     };
 
     use super::*;
-    use crate::{
-        historical::{HistoricalGateway, API_VERSION},
-        HistoricalClient,
-    };
+    use crate::{historical::API_VERSION, HistoricalClient};
 
-    const API_KEY: &str = "test-metadata";
+    const API_KEY: &str = "test-API________________________";
+
+    fn client(mock_server: &MockServer) -> HistoricalClient {
+        HistoricalClient::builder()
+            .base_url(mock_server.uri().parse().unwrap())
+            .key(API_KEY)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn test_list_fields() {
@@ -490,12 +496,7 @@ mod tests {
             )
             .mount(&mock_server)
             .await;
-        let mut target = HistoricalClient::with_url(
-            mock_server.uri(),
-            API_KEY.to_owned(),
-            HistoricalGateway::Bo1,
-        )
-        .unwrap();
+        let mut target = client(&mock_server);
         let fields = target
             .metadata()
             .list_fields(
@@ -566,12 +567,7 @@ mod tests {
             )
             .mount(&mock_server)
             .await;
-        let mut target = HistoricalClient::with_url(
-            mock_server.uri(),
-            API_KEY.to_owned(),
-            HistoricalGateway::Bo1,
-        )
-        .unwrap();
+        let mut target = client(&mock_server);
         let prices = target.metadata().list_unit_prices(DATASET).await.unwrap();
         assert_eq!(
             prices,
@@ -621,12 +617,7 @@ mod tests {
             )
             .mount(&mock_server)
             .await;
-        let mut target = HistoricalClient::with_url(
-            mock_server.uri(),
-            API_KEY.to_owned(),
-            HistoricalGateway::Bo1,
-        )
-        .unwrap();
+        let mut target = client(&mock_server);
         let condition = target
             .metadata()
             .get_dataset_condition(
@@ -694,12 +685,7 @@ mod tests {
             )
             .mount(&mock_server)
             .await;
-        let mut target = HistoricalClient::with_url(
-            mock_server.uri(),
-            API_KEY.to_owned(),
-            HistoricalGateway::Bo1,
-        )
-        .unwrap();
+        let mut target = client(&mock_server);
         let range = target.metadata().get_dataset_range(DATASET).await.unwrap();
         assert_eq!(range.start, datetime!(2019 - 07 - 07 00:00:00+00:00));
         assert_eq!(range.end, datetime!(2023 - 07 - 20 00:00:00.000000+00:00));

--- a/src/historical/symbology.rs
+++ b/src/historical/symbology.rs
@@ -201,13 +201,18 @@ mod tests {
     };
 
     use super::*;
-    use crate::{
-        body_contains,
-        historical::{HistoricalGateway, API_VERSION},
-        HistoricalClient,
-    };
+    use crate::{body_contains, historical::API_VERSION, HistoricalClient};
 
-    const API_KEY: &str = "test-API";
+    const API_KEY: &str = "test-API________________________";
+
+    fn client(mock_server: &MockServer) -> HistoricalClient {
+        HistoricalClient::builder()
+            .base_url(mock_server.uri().parse().unwrap())
+            .key(API_KEY)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn test_resolve() {
@@ -244,12 +249,7 @@ mod tests {
             )
             .mount(&mock_server)
             .await;
-        let mut target = HistoricalClient::with_url(
-            mock_server.uri(),
-            API_KEY.to_owned(),
-            HistoricalGateway::Bo1,
-        )
-        .unwrap();
+        let mut target = client(&mock_server);
         let res = target
             .symbology()
             .resolve(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,10 @@ pub use live::Client as LiveClient;
 // Re-export to keep versions synchronized
 pub use dbn;
 
-use std::fmt::{self, Display, Write};
+use std::{
+    fmt::{self, Display, Write},
+    sync::LazyLock,
+};
 
 #[cfg(feature = "historical")]
 use serde::{Deserialize, Deserializer};
@@ -273,6 +276,15 @@ pub(crate) fn body_contains(
 ) -> wiremock::matchers::BodyContainsMatcher {
     wiremock::matchers::body_string_contains(format!("{key}={val}"))
 }
+
+static USER_AGENT: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "Databento/{} Rust {}-{}",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+    )
+});
 
 #[cfg(test)]
 mod tests {

--- a/src/live.rs
+++ b/src/live.rs
@@ -59,6 +59,7 @@ pub struct ClientBuilder<AK, D> {
     upgrade_policy: VersionUpgradePolicy,
     heartbeat_interval: Option<Duration>,
     buf_size: Option<usize>,
+    user_agent_ext: Option<String>,
 }
 
 impl Default for ClientBuilder<Unset, Unset> {
@@ -71,6 +72,7 @@ impl Default for ClientBuilder<Unset, Unset> {
             upgrade_policy: VersionUpgradePolicy::default(),
             heartbeat_interval: None,
             buf_size: None,
+            user_agent_ext: None,
         }
     }
 }
@@ -129,6 +131,12 @@ impl<AK, D> ClientBuilder<AK, D> {
         self.addr = Some(Arc::new(addrs));
         Ok(self)
     }
+
+    /// Extends the user agent. Intended for library authors.
+    pub fn user_agent_extension(mut self, extension: String) -> Self {
+        self.user_agent_ext = Some(extension);
+        self
+    }
 }
 
 impl ClientBuilder<Unset, Unset> {
@@ -152,6 +160,7 @@ impl<D> ClientBuilder<Unset, D> {
             upgrade_policy: self.upgrade_policy,
             heartbeat_interval: self.heartbeat_interval,
             buf_size: self.buf_size,
+            user_agent_ext: self.user_agent_ext,
         })
     }
 
@@ -178,6 +187,7 @@ impl<AK> ClientBuilder<AK, Unset> {
             upgrade_policy: self.upgrade_policy,
             heartbeat_interval: self.heartbeat_interval,
             buf_size: self.buf_size,
+            user_agent_ext: self.user_agent_ext,
         }
     }
 }
@@ -189,27 +199,6 @@ impl ClientBuilder<ApiKey, String> {
     /// This function returns an error when its unable
     /// to connect and authenticate with the Live gateway.
     pub async fn build(self) -> crate::Result<Client> {
-        if let Some(addr) = self.addr {
-            Client::connect_with_addr_impl(
-                addr.as_slice(),
-                self.key.0,
-                self.dataset,
-                self.send_ts_out,
-                self.upgrade_policy,
-                self.heartbeat_interval,
-                self.buf_size,
-            )
-            .await
-        } else {
-            Client::connect_impl(
-                self.key.0,
-                self.dataset,
-                self.send_ts_out,
-                self.upgrade_policy,
-                self.heartbeat_interval,
-                self.buf_size,
-            )
-            .await
-        }
+        Client::new(self).await
     }
 }


### PR DESCRIPTION
##### Enhancements
- Added operating system info to the user agent to aid troubleshooting
- Standardized `client` info sent by live clients to match historical
- Added methods to the client builders to extend the user agents with a custom string

##### Deprecations
- Deprecated `Historical::with_url()`: use the builder to override the base URL
- Deprecated the `upgrade_policy` parameters for `timseries().get_range()` and
  `timeseries().get_range_to_file()`: use the `Historical` client parameter
  instead
