### PR TITLE
VER: Release 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.30.1 - TBD
+
+### Bug fixes
+- Removed unused `S3` and `Disk` variants from `Delivery` enum
+
 ## 0.30.0 - 2025-07-22
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,28 @@
 # Changelog
 
-## 0.30.1 - TBD
+## 0.31.0 - 2025-07-29
 
 ### Enhancements
 - Changed `timeseries.get_range_to_file()` to return a concrete type instead of an impl
   trait type
+- Upgraded DBN version to 0.39.0:
+  - Added `side()` and `unpaired_side()` methods to `ImbalanceMsg` that convert the fields
+    of the same name to the `Side` enum
+  - Added `pretty_auction_time` property in Python for `ImbalanceMsg`
+  - Added `Default` implementation for `StatUpdateAction`
+  - Added warnings to the floating-point getter methods' docstrings
+  - Added `action` and `ts_in_delta` getters to `BboMsg`
+  - Added `ts_recv` getter to `StatusMsg`
+  - Added missing floating-point price getters to `InstrumentDefMsg` record types from all
+    DBN versions
+  - Added more floating-point price getters to `ImbalanceMsg`
+  - Added floating-point price getter to `StatMsg` and `v1::StatMsg`
+
+### Breaking changes
+- Breaking changes from DBN:
+  - Changed `SystemMsg::code()` and `ErrorMsg::code()` methods to return a `Result`
+    instead of an `Option` to be consistent with other enum conversion methods
+  - Changed `auction_time` field in `ImbalanceMsg` to be formatted as a timestamp
 
 ### Bug fixes
 - Removed unused `S3` and `Disk` variants from `Delivery` enum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.30.1 - TBD
 
+### Enhancements
+- Changed `timeseries.get_range_to_file()` to return a concrete type instead of an impl
+  trait type
+
 ### Bug fixes
 - Removed unused `S3` and `Disk` variants from `Delivery` enum
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ historical = [
 live = ["dep:hex", "dep:sha2", "tokio/net"]
 
 [dependencies]
-dbn = { version = "0.38.0", features = ["async", "serde"] }
+dbn = { version = "0.39.0", features = ["async", "serde"] }
 
 async-compression = { version = "0.4", features = ["tokio", "zstd"], optional = true }
 # Async stream trait

--- a/src/historical/batch.rs
+++ b/src/historical/batch.rs
@@ -213,10 +213,6 @@ pub enum Delivery {
     /// Via download from the Databento portal.
     #[default]
     Download,
-    /// Via Amazon S3.
-    S3,
-    /// Via disk.
-    Disk,
 }
 
 /// The state of a batch job.
@@ -281,8 +277,8 @@ pub struct SubmitJobParams {
     /// Must be an integer between 1e9 and 10e9 inclusive (1GB - 10GB). Defaults to `None`.
     #[builder(default, setter(strip_option))]
     pub split_size: Option<NonZeroU64>,
-    /// The delivery mechanism for the batched data files once processed. Defaults to
-    /// [`Download`](Delivery::Download).
+    /// The delivery mechanism for the batched data files once processed.
+    /// Only [`Download`](Delivery::Download) is supported at this time.
     #[builder(default)]
     pub delivery: Delivery,
     /// The symbology type of the input `symbols`. Defaults to
@@ -463,8 +459,6 @@ impl Delivery {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Delivery::Download => "download",
-            Delivery::S3 => "s3",
-            Delivery::Disk => "disk",
         }
     }
 }
@@ -481,8 +475,6 @@ impl FromStr for Delivery {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "download" => Ok(Delivery::Download),
-            "s3" => Ok(Delivery::S3),
-            "disk" => Ok(Delivery::Disk),
             _ => Err(crate::Error::bad_arg(
                 "s",
                 format!(

--- a/src/historical/timeseries.rs
+++ b/src/historical/timeseries.rs
@@ -2,6 +2,7 @@
 
 use std::{num::NonZeroU64, path::PathBuf};
 
+use async_compression::tokio::bufread::ZstdDecoder;
 use dbn::{
     decode::DbnMetadata,
     encode::{AsyncDbnEncoder, AsyncEncodeRecordRef},
@@ -78,7 +79,7 @@ impl TimeseriesClient<'_> {
     pub async fn get_range_to_file(
         &mut self,
         params: &GetRangeToFileParams,
-    ) -> crate::Result<AsyncDbnDecoder<impl AsyncReadExt>> {
+    ) -> crate::Result<AsyncDbnDecoder<ZstdDecoder<BufReader<File>>>> {
         let reader = self
             .get_range_impl(
                 &params.dataset,


### PR DESCRIPTION
### Enhancements
- Changed `timeseries.get_range_to_file()` to return a concrete type instead of an impl
  trait type
- Upgraded DBN version to 0.39.0:
  - Added `side()` and `unpaired_side()` methods to `ImbalanceMsg` that convert the fields
    of the same name to the `Side` enum
  - Added `pretty_auction_time` property in Python for `ImbalanceMsg`
  - Added `Default` implementation for `StatUpdateAction`
  - Added warnings to the floating-point getter methods' docstrings
  - Added `action` and `ts_in_delta` getters to `BboMsg`
  - Added `ts_recv` getter to `StatusMsg`
  - Added missing floating-point price getters to `InstrumentDefMsg` record types from all
    DBN versions
  - Added more floating-point price getters to `ImbalanceMsg`
  - Added floating-point price getter to `StatMsg` and `v1::StatMsg`

### Breaking changes
- Breaking changes from DBN:
  - Changed `SystemMsg::code()` and `ErrorMsg::code()` methods to return a `Result`
    instead of an `Option` to be consistent with other enum conversion methods
  - Changed `auction_time` field in `ImbalanceMsg` to be formatted as a timestamp

### Bug fixes
- Removed unused `S3` and `Disk` variants from `Delivery` enum
