### PR TITLE
Added support for passing in None to SubscriptionBuilder::start().

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,37 @@ static USER_AGENT: LazyLock<String> = LazyLock::new(|| {
     )
 });
 
+mod private {
+    pub trait Sealed {}
+
+    impl<T: super::DateTimeLike> Sealed for T {}
+    impl<T: super::DateTimeLike> Sealed for Option<T> {}
+}
+
+/// A value that can be infallibly converted into `Option<OffsetDateTime>`.
+///
+/// This is a convenience trait for APIs that should accept either:
+/// - a concrete `T: DateTimeLike`, which becomes `Some(...)`, or
+/// - `Option<T>`, which maps `Some(...)` and preserves `None`.
+///
+/// This trait is sealed and is not intended for downstream implementation.
+pub trait DateTimeLikeOpt: private::Sealed {
+    /// Converts this value into an optional datetime.
+    fn to_date_time_opt(self) -> Option<time::OffsetDateTime>;
+}
+
+impl<T: DateTimeLike> DateTimeLikeOpt for T {
+    fn to_date_time_opt(self) -> Option<time::OffsetDateTime> {
+        Some(self.to_date_time())
+    }
+}
+
+impl<T: DateTimeLike> DateTimeLikeOpt for Option<T> {
+    fn to_date_time_opt(self) -> Option<time::OffsetDateTime> {
+        self.map(DateTimeLike::to_date_time)
+    }
+}
+
 /// A datetime or object that can be non-fallibly converted to a datetime.
 pub trait DateTimeLike {
     /// Converts the object to a datetime.

--- a/src/live.rs
+++ b/src/live.rs
@@ -11,7 +11,7 @@ use tokio::net::{lookup_host, ToSocketAddrs};
 use tracing::warn;
 use typed_builder::TypedBuilder;
 
-use crate::{ApiKey, DateTimeLike, Symbols};
+use crate::{ApiKey, DateTimeLikeOpt, Symbols};
 
 pub use client::Client;
 
@@ -60,7 +60,7 @@ pub struct Subscription {
     ///
     /// Cannot be specified after the session is started with [`LiveClient::start`](crate::LiveClient::start).
     /// See [`Intraday Replay`](https://databento.com/docs/api-reference-live/basics/intraday-replay).
-    #[builder(default, setter(transform = |dt: impl DateTimeLike| Some(dt.to_date_time())))]
+    #[builder(default, setter(transform = |dt: impl DateTimeLikeOpt| dt.to_date_time_opt()))]
     pub start: Option<OffsetDateTime>,
     #[doc(hidden)]
     /// Request subscription with snapshot. Only supported with `Mbo` schema.
@@ -298,6 +298,18 @@ mod tests {
             .symbols("AAPL")
             .schema(Schema::Trades)
             .start(date)
+            .build();
+        assert_eq!(sub.start, Some(datetime!(2024-03-15 00:00:00 UTC)));
+    }
+
+    #[test]
+    fn subscription_with_time_date_or_none() {
+        let date = time::macros::date!(2024 - 03 - 15);
+        let flag = true;
+        let sub = Subscription::builder()
+            .symbols("AAPL")
+            .schema(Schema::Trades)
+            .start(if flag { Some(date) } else { None })
             .build();
         assert_eq!(sub.start, Some(datetime!(2024-03-15 00:00:00 UTC)));
     }


### PR DESCRIPTION
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

Currently it is awkward to pass in the `start()` DateTime dynamically since the `TypedBuilder` changes type.

Note: something like 
```
setter(
    fn transform<T: DateTimeLike>(dt: impl Into<Option<T>>) -> Option<OffsetDateTime> {
        dt.into().map(|dt| dt.to_date_time())
    }
)
```
does not work well since it breaks type inference when passed in a `Some(T)` since it technically allows `Some(T)` to be converted into `Some(T2)`.